### PR TITLE
add cardInfo, originalOwner, and verificationType to Card class

### DIFF
--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -275,6 +275,15 @@ class User:
     self.status = user_obj.get("status")
     self.groups = [Group(group) for group in data.get("groups", [])]
 
+class UserGroup:
+  def __init__(self, data):
+    user_group_obj = data.get("userGroup") or data or {}
+    self.email = user_group_obj.get("id")
+    self.email = user_group_obj.get("modifiable")
+    self.email = user_group_obj.get("name")
+    self.email = user_group_obj.get("numberOfCardsAsVerifier")
+    self.email = user_group_obj.get("numberOfMembers")
+
 
 class Tag:
   def __init__(self, data):
@@ -291,11 +300,27 @@ class Tag:
       "categoryId": self.category_id,
     }
 
+class Verifier:
+  def __init__(self, data):
+    self.id = data.get("id")
+    self.type = data.get("type")
+    self.user = User(data.get("user")) if data.get("user") else None
+    self.user_group = UserGroup(data.get("userGroup")) if data.get("userGroup") else None
+
+class CardInfo:
+  def __init__(self, data):
+    card_info_obj = data.get("analytics") or data or {}
+    self.email = card_info_obj.get("boards")
+    self.email = card_info_obj.get("copies")
+    self.email = card_info_obj.get("favorites")
+    self.email = card_info_obj.get("unverifiedCopies")
+    self.email = card_info_obj.get("unverifiedViews")
+    self.email = card_info_obj.get("views")
 
 class Card:
   def __init__(self, data, guru=None):
     self.guru = guru
-    self.card_info = data.get("cardInfo")
+    self.card_info = CardInfo(data.get("cardInfo")) if data.get("cardInfo") else None
     self.type = data.get("cardType") or "CARD"
     self.collection = Collection(data.get("collection")) if data.get("collection") else None
     self.__content = data.get("content", "")
@@ -319,6 +344,7 @@ class Card:
     self.verification_reason = data.get("verificationReason")
     self.verification_state = data.get("verificationState")
     self.verification_type = data.get("verificationType")
+    self.verifiers = [Verifier(v, guru) for v in data.get("verifiers") or []]
     self.version = data.get("version")
     self.archived = data.get("archived")
     self.boards = [Board(b, guru) for b in data.get("boards") or []]

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -295,22 +295,19 @@ class Verifier:
     self.id = data.get("id")
     self.type = data.get("type")
     self.user = User(data.get("user")) if data.get("user") else None
-    self.user_group = Group(data.get("userGroup")) if data.get("userGroup") else None
+    self.group = Group(data.get("userGroup")) if data.get("userGroup") else None
 
-class CardInfo:
-  def __init__(self, data):
-    card_info_obj = data.get("analytics") or data or {}
-    self.boards = card_info_obj.get("boards")
-    self.copies = card_info_obj.get("copies")
-    self.favorites = card_info_obj.get("favorites")
-    self.unverified_copies = card_info_obj.get("unverifiedCopies")
-    self.unverified_views = card_info_obj.get("unverifiedViews")
-    self.views = card_info_obj.get("views")
 
 class Card:
   def __init__(self, data, guru=None):
+    analytics = data.get("cardInfo", {}).get("analytics", {})
     self.guru = guru
-    self.card_info = CardInfo(data.get("cardInfo")) if data.get("cardInfo") else None
+    self.board_count = analytics.get("boards")
+    self.copies = analytics.get("copies")
+    self.favorites = analytics.get("favorites")
+    self.unverified_copies = analytics.get("unverifiedCopies")
+    self.unverified_views = analytics.get("unverifiedViews")
+    self.views = analytics.get("views")
     self.type = data.get("cardType") or "CARD"
     self.collection = Collection(data.get("collection")) if data.get("collection") else None
     self.__content = data.get("content", "")

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -295,6 +295,7 @@ class Tag:
 class Card:
   def __init__(self, data, guru=None):
     self.guru = guru
+    self.card_info = data.get("cardInfo")
     self.type = data.get("cardType") or "CARD"
     self.collection = Collection(data.get("collection")) if data.get("collection") else None
     self.__content = data.get("content", "")
@@ -306,6 +307,7 @@ class Card:
     self.last_verified_by = User(data.get("lastVerifiedBy")) if data.get("lastVerifiedBy") else None
     self.next_verification_date = data.get("nextVerificationDate")
     self.owner = User(data.get("owner")) if data.get("owner") else None
+    self.original_owner = User(data.get("originalOwner")) if data.get("originalOwner") else None
     self.title = data.get("preferredPhrase", "")
     self.share_status = data.get("shareStatus", "TEAM")
     self.slug = data.get("slug")
@@ -316,6 +318,7 @@ class Card:
     self.verification_interval = data.get("verificationInterval")
     self.verification_reason = data.get("verificationReason")
     self.verification_state = data.get("verificationState")
+    self.verification_type = data.get("verificationType")
     self.version = data.get("version")
     self.archived = data.get("archived")
     self.boards = [Board(b, guru) for b in data.get("boards") or []]

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -334,7 +334,7 @@ class Card:
     self.verification_reason = data.get("verificationReason")
     self.verification_state = data.get("verificationState")
     self.verification_type = data.get("verificationType")
-    self.verifiers = [Verifier(v, guru) for v in data.get("verifiers") or []]
+    self.verifiers = [Verifier(v) for v in data.get("verifiers") or []]
     self.version = data.get("version")
     self.archived = data.get("archived")
     self.boards = [Board(b, guru) for b in data.get("boards") or []]

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -275,16 +275,6 @@ class User:
     self.status = user_obj.get("status")
     self.groups = [Group(group) for group in data.get("groups", [])]
 
-class UserGroup:
-  def __init__(self, data):
-    user_group_obj = data.get("userGroup") or data or {}
-    self.email = user_group_obj.get("id")
-    self.email = user_group_obj.get("modifiable")
-    self.email = user_group_obj.get("name")
-    self.email = user_group_obj.get("numberOfCardsAsVerifier")
-    self.email = user_group_obj.get("numberOfMembers")
-
-
 class Tag:
   def __init__(self, data):
     self.id = data.get("id")
@@ -305,17 +295,17 @@ class Verifier:
     self.id = data.get("id")
     self.type = data.get("type")
     self.user = User(data.get("user")) if data.get("user") else None
-    self.user_group = UserGroup(data.get("userGroup")) if data.get("userGroup") else None
+    self.user_group = Group(data.get("userGroup")) if data.get("userGroup") else None
 
 class CardInfo:
   def __init__(self, data):
     card_info_obj = data.get("analytics") or data or {}
-    self.email = card_info_obj.get("boards")
-    self.email = card_info_obj.get("copies")
-    self.email = card_info_obj.get("favorites")
-    self.email = card_info_obj.get("unverifiedCopies")
-    self.email = card_info_obj.get("unverifiedViews")
-    self.email = card_info_obj.get("views")
+    self.boards = card_info_obj.get("boards")
+    self.copies = card_info_obj.get("copies")
+    self.favorites = card_info_obj.get("favorites")
+    self.unverified_copies = card_info_obj.get("unverifiedCopies")
+    self.unverified_views = card_info_obj.get("unverifiedViews")
+    self.views = card_info_obj.get("views")
 
 class Card:
   def __init__(self, data, guru=None):

--- a/tests/test_core_cards.py
+++ b/tests/test_core_cards.py
@@ -74,6 +74,73 @@ class TestCore(unittest.TestCase):
 
   @use_guru()
   @responses.activate
+  def test_get_card_and_check_verifier(self, g):
+    # register the response for the API call we'll make.
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/mycard1", json={
+      "verifiers": [
+        {
+          "type": "user",
+          "user": {
+            "status": "ACTIVE",
+            "email": "jchappelle@getguru.com",
+            "firstName": "John",
+            "lastName": "Chappelle",
+            "profilePicUrl": "/assets/common/images/default-user-pic.png"
+          },
+          "id": "jchappelle@getguru.com"
+        }
+      ]
+    })
+
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/mycard2", json={
+      "verifiers": [
+        {
+          "type": "user-group",
+          "userGroup": {
+            "name": "Customer Experience",
+            "id": "123472f8-a1e7-4b99-8849-7a7186323203",
+            "modifiable": False
+          },
+          "id": "123472f8-a1e7-4b99-8849-7a7186323203"
+        }
+      ]
+    })
+
+    # this should trigger the GET call we're expecting.
+    card1 = g.get_card("mycard1")
+    card2 = g.get_card("mycard2")
+
+    self.assertEqual(card1.verifiers[0].type, "user")
+    self.assertEqual(card1.verifiers[0].user.email, "jchappelle@getguru.com")
+
+    self.assertEqual(card2.verifiers[0].type, "user-group")
+    self.assertEqual(card2.verifiers[0].user_group.name, "Customer Experience")
+
+  @use_guru()
+  @responses.activate
+  def test_get_card_and_check_card_info(self, g):
+    # register the response for the API call we'll make.
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/mycard", json={
+      "id": "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+      "cardInfo": {
+        "analytics": {
+          "boards": 1,
+          "copies": 5,
+          "favorites": 2,
+          "unverifiedCopies": 0,
+          "unverifiedViews": 0,
+          "views": 36,
+        }
+      }
+    })
+
+    card = g.get_card("mycard")
+
+    self.assertEqual(card.card_info.copies, 5)
+    self.assertEqual(card.card_info.views, 36)
+
+  @use_guru()
+  @responses.activate
   def test_make_card(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/collections", json=[{
       "id": "1234",

--- a/tests/test_core_cards.py
+++ b/tests/test_core_cards.py
@@ -114,7 +114,7 @@ class TestCore(unittest.TestCase):
     self.assertEqual(card1.verifiers[0].user.email, "jchappelle@getguru.com")
 
     self.assertEqual(card2.verifiers[0].type, "user-group")
-    self.assertEqual(card2.verifiers[0].user_group.name, "Customer Experience")
+    self.assertEqual(card2.verifiers[0].group.name, "Customer Experience")
 
   @use_guru()
   @responses.activate
@@ -136,8 +136,8 @@ class TestCore(unittest.TestCase):
 
     card = g.get_card("mycard")
 
-    self.assertEqual(card.card_info.copies, 5)
-    self.assertEqual(card.card_info.views, 36)
+    self.assertEqual(card.copies, 5)
+    self.assertEqual(card.views, 36)
 
   @use_guru()
   @responses.activate


### PR DESCRIPTION
## Overview

This adds cardInfo, originalOwner, and verificationType to the `Card` class. I'm doing this now, so that I can write a script for generating a card export csv, and we need the cardInfo and originalOwner to replicate what `Export` from card manager gives you.

I don't think this addition requires a test, but I can figure out a way to use it, if we do need this.