### PR TITLE
add board.move_to_collection method

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -1629,7 +1629,7 @@ class Guru:
     response = self.__delete(url)
     return status_to_bool(response.status_code)
 
-  def move_board_to_collection(self, board, collection, timeout=0, interval=2):
+  def move_board_to_collection(self, board, collection, timeout=0):
     """
     Moves a board from one collection to another.
 
@@ -1689,12 +1689,12 @@ class Guru:
 
     elapsed = 0
     while True:
-      time.sleep(interval)
+      time.sleep(2)
       response = self.__get(url)
       if response.status_code == 200:
         return True
 
-      elapsed += interval
+      elapsed += 2
       if elapsed >= timeout:
         break
 

--- a/guru/core.py
+++ b/guru/core.py
@@ -1,6 +1,7 @@
 
 import os
 import re
+import time
 import requests
 
 from requests.auth import HTTPBasicAuth
@@ -815,7 +816,7 @@ class Guru:
     if cards:
       return cards[0]
 
-  def find_cards(self, title="", tag="", collection=""):
+  def find_cards(self, title="", tag="", collection="", archived=False):
     """
     Gets a list of cards that match the criteria defined by the parameters.
     You can include any combination of title, tag, and collection to
@@ -848,16 +849,16 @@ class Guru:
 
     # if a collection name was provided, look it up.
     if collection:
-      c = self.get_collection(collection, cache=True)
-      if not c:
+      collection_obj = self.get_collection(collection, cache=True)
+      if not collection_obj:
         raise BaseException("collection '%s' not found" % collection)
 
-      data["collectionIds"] = [c.id]
+      data["collectionIds"] = [collection_obj.id]
 
     # if no tag value was passed in, get_tag() will return nothing.
     if tag:
-      tag_object = self.get_tag(tag)
-      if not tag_object:
+      tag_obj = self.get_tag(tag)
+      if not tag_obj:
         self.__log(make_red("could not find tag:", tag))
         return []
       
@@ -866,7 +867,7 @@ class Guru:
           {
             "type": "tag",
             "ids": [
-              tag_object.id
+              tag_obj.id
             ],
             "op": "EXISTS"
           }
@@ -1627,3 +1628,74 @@ class Guru:
     url = "%s/boards/%s/permissions/%s" % (self.base_url, board_obj.id, perm_obj.id)
     response = self.__delete(url)
     return status_to_bool(response.status_code)
+
+  def move_board_to_collection(self, board, collection, timeout=0, interval=2):
+    """
+    Moves a board from one collection to another.
+
+    Args:
+      board (str or Board): The board to be moved. Can either be the board's title,
+        ID, slug, or the Board object.
+      collection (str or Collection): The collection you're moving the board to. Can
+        either be the collection's title, ID, or the Collection object.
+      timeout (int, optional): The API call to move a board just queues up the operation.
+        This parameter is used if you want to wait until Guru is done moving the board to
+        its new collection. This helpful if you want to do multiple operations, like move
+        a board to a new collection then add it to a board group there. By default this is
+        0 so it doesn't wait. If you set a timeout of 10, we'll wait up to 10 seconds to
+        see if the move completes.
+
+    Returns:
+      bool: True if it was successful and False otherwise. False could mean that there was
+        an error or that you were waiting for the operation to finish and it timed out.
+    """
+    board_obj = self.get_board(board, collection=collection)
+    if not board_obj:
+      self.__log(make_red("could not find board:", board))
+      return
+
+    collection_obj = self.get_collection(collection)
+    if not collection_obj:
+      self.__log(make_red("could not find collection:", collection))
+      return
+
+    # if the board is already in that collection, do nothing.
+    if board_obj.collection and board_obj.collection.id == collection_obj.id:
+      self.__log(make_red("board", board_obj.title, "is already in collection", collection_obj.name))
+      return
+
+    # make the bulk op call to move the board to the other collection.
+    data = {
+      "action": {
+        "type": "move-board",
+        "collectionId": collection_obj.id
+      },
+      "items": {
+        "type": "id",
+        "itemIds": [board_obj.id]
+      }
+    }
+
+    url = "%s/boards/bulkop" % self.base_url
+    response = self.__post(url, data)
+
+    # if there's no timeout we're done once we submit the bulk operation.
+    if not timeout:
+      return status_to_bool(response.status_code)
+
+    # poll and wait for the bulk operation to finish.
+    bulk_op_id = response.json().get("id")
+    url = "%s/boards/bulkop/%s" % (self.base_url, bulk_op_id)
+
+    elapsed = 0
+    while True:
+      time.sleep(interval)
+      response = self.__get(url)
+      if response.status_code == 200:
+        return True
+
+      elapsed += interval
+      if elapsed >= timeout:
+        break
+
+    return False

--- a/guru/core.py
+++ b/guru/core.py
@@ -816,7 +816,7 @@ class Guru:
     if cards:
       return cards[0]
 
-  def find_cards(self, title="", tag="", collection="", archived=False):
+  def find_cards(self, title="", tag="", collection=""):
     """
     Gets a list of cards that match the criteria defined by the parameters.
     You can include any combination of title, tag, and collection to

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -105,6 +105,9 @@ class Board:
   def remove_group(self, group):
     return self.guru.remove_shared_group(self, group)
 
+  def move_to_collection(self, collection, timeout=0, interval=2):
+    self.guru.move_board_to_collection(self, collection, timeout, interval)
+
   def json(self, include_items=True, include_item_id=False, include_collection=True):
     data = {
       "id": self.id,
@@ -136,6 +139,7 @@ class BoardGroup:
     self.home_board = home_board
     self.title = data.get("title")
     self.item_id = data.get("itemId")
+    self.description = data.get("description") or ""
     self.slug = data.get("slug")
     self.id = data.get("id")
     self.type = "board-group"

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -105,8 +105,8 @@ class Board:
   def remove_group(self, group):
     return self.guru.remove_shared_group(self, group)
 
-  def move_to_collection(self, collection, timeout=0, interval=2):
-    self.guru.move_board_to_collection(self, collection, timeout, interval)
+  def move_to_collection(self, collection, timeout=0):
+    self.guru.move_board_to_collection(self, collection, timeout)
 
   def json(self, include_items=True, include_item_id=False, include_collection=True):
     data = {

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -4,8 +4,7 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
+from unittest.mock import Mock
 
 import guru
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 from tests.util import use_guru, get_calls
 
 import guru

--- a/tests/test_core_boards.py
+++ b/tests/test_core_boards.py
@@ -1,11 +1,11 @@
 
 import json
 import yaml
+import time
 import unittest
 import responses
 
 from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
 
 from tests.util import use_guru, get_calls
 
@@ -1131,8 +1131,9 @@ class TestCore(unittest.TestCase):
     })
     responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/bulkop/2222", json={})
 
-    board = g.get_board("11111111-1111-1111-1111-111111111111")
-    board.move_to_collection("General", timeout=0.1, interval=0.2)
+    with patch("time.sleep", Mock(return_value=None)):
+      board = g.get_board("11111111-1111-1111-1111-111111111111")
+      board.move_to_collection("General", timeout=1)
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
@@ -1245,8 +1246,9 @@ class TestCore(unittest.TestCase):
     })
     responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/bulkop/2222", status=204)
 
-    board = g.get_board("11111111-1111-1111-1111-111111111111")
-    board.move_to_collection("General", timeout=0.3, interval=0.2)
+    with patch("time.sleep", Mock(return_value=None)):
+      board = g.get_board("11111111-1111-1111-1111-111111111111")
+      board.move_to_collection("General", timeout=3)
 
     self.assertEqual(get_calls(), [{
       "method": "GET",

--- a/tests/test_core_cache.py
+++ b/tests/test_core_cache.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 from tests.util import use_guru, get_calls
 
 import guru

--- a/tests/test_core_cards.py
+++ b/tests/test_core_cards.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 from tests.util import use_guru, get_calls
 
 import guru

--- a/tests/test_core_groups_and_collections.py
+++ b/tests/test_core_groups_and_collections.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 from tests.util import use_guru, get_calls
 
 import guru

--- a/tests/test_core_tags.py
+++ b/tests/test_core_tags.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 from tests.util import use_guru, get_calls
 
 import guru

--- a/tests/test_core_users.py
+++ b/tests/test_core_users.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 from tests.util import use_guru, get_calls
 
 import guru

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 from tests.util import use_guru, get_calls
 
 import guru

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,9 +4,6 @@ import yaml
 import unittest
 import responses
 
-from unittest.mock import Mock, patch
-from requests.auth import HTTPBasicAuth
-
 import guru
 
 def read_html(filename):


### PR DESCRIPTION
Moving a board to another collection is done as a bulk operation which is asynchronous on our backend, so the method here also has logic to poll and wait for the operation to complete. That way, if you want to move 3 boards to another collection then do something once they're done, your script can wait and know when those operations finish.

The `timeout` parameter is what you use to indicate if you want to poll and wait for the bulkop to finish and to also specify how long you'll wait. It checks every 2 seconds.

This also cleans up some variable names to use the `_obj` suffix -- e.g. `collection` could be a collection ID, name, or an instance of the Collection class, but `collection_obj` is definitely an instance of Collection (or it's null).

Lastly, I noticed tests copied and pasted the same imports for Mock, patch, and HTTPBasicAuth but most didn't actually use them, so I removed these extra imports.