### PR TITLE
Expand end-to-end tests

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -1,12 +1,18 @@
 
 import os
 import re
+import sys
 import requests
 
 from requests.auth import HTTPBasicAuth
 
+if sys.version_info.major >= 3:
+  from urllib.parse import quote
+else:
+  from urlparse import quote
+
 from guru.bundle import Bundle
-from guru.data_objects import Board, BoardGroup, BoardPermission, Card, CardComment, Collection, Draft, Group, HomeBoard, Tag, User
+from guru.data_objects import Board, BoardGroup, BoardPermission, Card, CardComment, Collection, CollectionAccess, Draft, Group, HomeBoard, Tag, User
 from guru.util import find_by_name_or_id, find_by_email, find_by_id
 
 # collection colors
@@ -246,7 +252,7 @@ class Guru:
     elif self.__is_id(collection):
       url = "%s/collections/%s" % (self.base_url, collection)
       response = self.__get(url, cache)
-      return Collection(response.json())
+      return Collection(response.json(), guru=self)
     else:
       # we compare the name and ID because you can pass either.
       # and if the names aren't unique, you'll need to pass an ID.
@@ -267,7 +273,7 @@ class Guru:
     """
     url = "%s/collections" % self.base_url
     response = self.__get(url, cache)
-    return [Collection(c) for c in response.json()]
+    return [Collection(c, guru=self) for c in response.json()]
 
   def make_collection(self, name, desc="", color=GREEN, is_sync=False, group="All Members", public_cards=True):
     """
@@ -317,7 +323,17 @@ class Guru:
 
     url = "%s/collections" % self.base_url
     response = self.__post(url, data)
-    return Collection(response.json())
+    return Collection(response.json(), guru=self)
+
+  def get_groups_on_collection(self, collection):
+    collection_obj = self.get_collection(collection, cache=True)
+    if not collection_obj:
+      self.__log(make_red("could not find collection:", collection))
+      return
+
+    url = "%s/collections/%s/groups" % (self.base_url, collection_obj.id)
+    response = self.__get(url)
+    return [CollectionAccess(ca) for ca in response.json()]
 
   def add_group_to_collection(self, group, collection, role):
     """
@@ -523,7 +539,7 @@ class Guru:
     """
 
     members = []
-    url = "%s/members?search=%s" % (self.base_url, search)
+    url = "%s/members?search=%s" % (self.base_url, quote(search))
     users = self.__get_and_get_all(url, cache)
     users = [User(u) for u in users]
     return users

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -94,7 +94,15 @@ class Board:
     return self.guru.set_item_order(self.collection, self, *items)
 
   def get_card(self, card):
+    if isinstance(card, Card):
+      card = card.id
     return find_by_name_or_id(self.__cards, card)
+
+  def add_card(self, card, section=None):
+    return self.guru.add_card_to_board(card, self, section=section)
+
+  def remove_card(self, card):
+    return self.guru.remove_card_from_board(card, self)
 
   def get_groups(self):
     return self.guru.get_shared_groups(self)
@@ -220,7 +228,9 @@ class Group:
 
 
 class Collection:
-  def __init__(self, data):
+  def __init__(self, data, guru=None):
+    self.guru = guru
+
     # these are the properties you always get, like when a card has a nested
     # collection object with just a few properties.
     self.id = data.get("id")
@@ -249,6 +259,15 @@ class Collection:
   def title(self, title):
     self.name = title
 
+  def add_group(self, group, role):
+    return self.guru.add_group_to_collection(group, self, role)
+
+  def remove_group(self, group):
+    return self.guru.remove_group_from_collection(group, self)
+
+  def get_groups(self):
+    return self.guru.get_groups_on_collection(self)
+
   def json(self):
     return {
       "id": self.id,
@@ -256,6 +275,13 @@ class Collection:
       "type": self.type,
       "color": self.color,
     }
+
+
+class CollectionAccess:
+  def __init__(self, data):
+    self.group_name = data.get("groupName")
+    self.group_id = data.get("groupId")
+    self.role = data.get("role")
 
 
 class CollectionStats:
@@ -275,6 +301,8 @@ class User:
     self.status = user_obj.get("status")
     self.groups = [Group(group) for group in data.get("groups", [])]
 
+  def has_group(self, group):
+    return True if find_by_name_or_id(self.groups, group) else False
 
 class Tag:
   def __init__(self, data):
@@ -317,7 +345,8 @@ class Card:
     self.verification_reason = data.get("verificationReason")
     self.verification_state = data.get("verificationState")
     self.version = data.get("version")
-    self.archived = data.get("archived")
+    self.archived = data.get("archived", False)
+    self.favorited = data.get("favorited", False)
     self.boards = [Board(b, guru) for b in data.get("boards") or []]
     self.__doc = None
 

--- a/tests/test_core_cache.py
+++ b/tests/test_core_cache.py
@@ -46,7 +46,7 @@ class TestCoreCache(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_that_the_cache_is_cleared_after_creating_a_group(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -76,7 +76,7 @@ class TestCoreCache(unittest.TestCase):
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups",
@@ -89,7 +89,7 @@ class TestCoreCache(unittest.TestCase):
       }
     }, {
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"

--- a/tests/test_core_users.py
+++ b/tests/test_core_users.py
@@ -39,7 +39,7 @@ class TestCore(unittest.TestCase):
       "name": "other group"
     }])
     responses.add(responses.POST, "https://api.getguru.com/api/v1/members/invite", json={})
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -56,7 +56,7 @@ class TestCore(unittest.TestCase):
       }
     }, {
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"
@@ -82,7 +82,7 @@ class TestCore(unittest.TestCase):
       "name": "Experts"
     }])
     responses.add(responses.POST, "https://api.getguru.com/api/v1/members/invite", json={})
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -97,7 +97,7 @@ class TestCore(unittest.TestCase):
       }
     }, {
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"
@@ -106,7 +106,7 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_add_user_to_group(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -120,7 +120,7 @@ class TestCore(unittest.TestCase):
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"
@@ -135,7 +135,7 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_add_user_to_invalid_group(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -148,7 +148,7 @@ class TestCore(unittest.TestCase):
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"
@@ -157,7 +157,7 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_add_user_to_groups(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -175,7 +175,7 @@ class TestCore(unittest.TestCase):
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"
@@ -196,7 +196,7 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_add_user_to_groups_where_first_one_is_invalid(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -215,7 +215,7 @@ class TestCore(unittest.TestCase):
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"
@@ -230,7 +230,7 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_add_user_to_groups_where_second_one_is_invalid(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": []
     }])
@@ -249,7 +249,7 @@ class TestCore(unittest.TestCase):
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"
@@ -264,19 +264,19 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_add_user_to_groups_with_invalid_user(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=invalid@example.com", json=[])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=invalid%40example.com", json=[])
     result = g.add_user_to_groups("invalid@example.com", "Experts")
 
     self.assertEqual(result, None)
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=invalid@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=invalid%40example.com"
     }])
 
   @use_guru()
   @responses.activate
   def test_add_user_to_groups_where_the_user_is_already_in_one_group(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user@example.com", json=[{
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
       "groups": [{
         "id": "1111",
@@ -300,7 +300,7 @@ class TestCore(unittest.TestCase):
     })
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user@example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/groups"


### PR DESCRIPTION
This expands the end-to-end tests to cover the happy path for most of the functions we have. It doesn't cover some things since we'd need to be able to do, then undo, anything we're testing this way.

```
Name                   Stmts   Miss Before  After Change
--------------------------------------------------------
guru/__init__.py           3      0   100%   100%     0%
guru/bundle.py           450    397    12%    12%     0%
guru/core.py             756    490    35%    69%   +34%
guru/data_objects.py     307     56    82%    90%    +8%
guru/publish.py          191    154    19%    19%     0%
guru/util.py             112     75    33%    38%    +5%
--------------------------------------------------------
TOTAL                   1819   1172    36%    52%   +16%
```

The changes here are:

 - Add the `CollectionAccess` object and a method to get the list of groups on a collection -- we already had methods to add/remove groups from a collection but for the e2e test we need to be able to get the list of groups to make sure the operations worked.
 - Escape URL parameters in the `/members?search` call (and update the unit tests to have `%40` instead of `@`).
 - Add some helper methods to the data objects (e.g. `board.add_card`)
 - Add the `favorited` property to the Card object.
 - Add more end-to-end tests to cover the happy path for almost all of the things we can test.