### PR TITLE
Add ability to get all archived cards to Py-SDK

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -853,7 +853,7 @@ class Guru:
     url = "%s/search/cardmgr" % self.base_url
     # look up the tag and include its id here.
 
-    if archived == True:
+    if archived:
       data = {
         "queryType": "archived",
         "sorts": None,

--- a/guru/core.py
+++ b/guru/core.py
@@ -815,7 +815,7 @@ class Guru:
     if cards:
       return cards[0]
 
-  def find_cards(self, title="", tag="", collection=""):
+  def find_cards(self, title="", tag="", collection="", archived=False):
     """
     Gets a list of cards that match the criteria defined by the parameters.
     You can include any combination of title, tag, and collection to
@@ -826,6 +826,8 @@ class Guru:
         is not case sensitive.
       tag (str, optional): The name or ID of a tag.
       collection (str, optional): The name or ID of a collection.
+      archived (bool, optional): Sets the query to search archived cards. 
+        Can be mixed with title, tag, and/ or collection.
     
     Returns:
       list of Card: The cards that matched the parameters you provided.
@@ -834,17 +836,25 @@ class Guru:
     url = "%s/search/cardmgr" % self.base_url
     # look up the tag and include its id here.
 
-    data = {
-      "queryType": None,
-      "sorts": [
-        {
-          "type": "verificationState",
-          "dir": "ASC"
-        }
-      ],
-      "query": None,
-      "collectionIds": []
-    }
+    if archived == True:
+      data = {
+        "queryType": "archived",
+        "sorts": None,
+        "query": None,
+        "collectionIds": []
+      }
+    else:
+      data = {
+        "queryType": None,
+        "sorts": [
+          {
+            "type": "verificationState",
+            "dir": "ASC"
+          }
+        ],
+        "query": None,
+        "collectionIds": []
+      }
 
     # if a collection name was provided, look it up.
     if collection:

--- a/tests/test_core_cards.py
+++ b/tests/test_core_cards.py
@@ -434,6 +434,24 @@ class TestCore(unittest.TestCase):
         "collectionIds": []
       }
     }])
+  
+  @use_guru()
+  @responses.activate
+  def test_find_archived_cards(self, g):
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/search/cardmgr", json=[])
+
+    g.find_cards(archived=True)
+
+    self.assertEqual(get_calls(), [{
+      "method": "POST",
+      "url": "https://api.getguru.com/api/v1/search/cardmgr",
+      "body": {
+        "queryType": "archived",
+        "sorts": None,
+        "query": None,
+        "collectionIds": []
+      }
+    }])
 
   @use_guru()
   @responses.activate


### PR DESCRIPTION
Story details: https://app.clubhouse.io/guru/story/42498

This PR adds an `archived` param to `find_cards()`. This `archived` param will default to `False`, but if set to `True`, a `find_cards()` call will return all archived cards that the user has collection access to. 
This can be used interchangeably with the other accepted params ( `title`, `collection`, `tag` ) to return archived cards, filtered by param(s).

Debating whether I should add an example to the `examples` directory.