### PR TITLE
add spreadsheet reports and a few other things

### DIFF
--- a/examples/find_external_images.py
+++ b/examples/find_external_images.py
@@ -1,0 +1,28 @@
+import guru
+
+g = guru.Guru()
+
+# convert a string like "https://lh6.googleusercontent.com/something.png" to just "googleusercontent.com".
+def get_image_domain(src):
+  src = src.replace("http://", "").replace("https://", "")
+  src = src.split("/")[0]
+  return ".".join(src.split(".")[-2:])
+
+# scan all cards, find ones that contain images that are hosted externally.
+for card in g.find_cards():
+  non_guru_domains = []
+  for image in card.doc.select("img"):
+    domain = get_image_domain(image.attrs["src"])
+    if domain != "getguru.com":
+      if domain not in non_guru_domains:
+        non_guru_domains.append(domain)
+
+  for domain in non_guru_domains:
+    print("\t".join([
+      card.collection.name,
+      card.title,
+      card.url,
+      card.verifier_label,
+      card.owner.email,
+      domain
+    ]))

--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -171,6 +171,7 @@ def make_spreadsheet(node, parent, depth, rows):
       "Title",
       "HTML Length",
       "# of HTML Tags",
+      "# of Essential HTML Tags",
       "Word Count",
       "Headings",
       "Iframes",
@@ -195,9 +196,15 @@ def make_spreadsheet(node, parent, depth, rows):
   # like word count, # of headings, # of links, etc.
   if node.type == CARD:
     doc = BeautifulSoup(node.content, "html.parser")
+    # these are the tag types that are absolutely essential, otherwise
+    # we're changing what the content looks like. some other tags, like
+    # divs, might be required to format the content correctly, but there's
+    # also a chance that some divs aren't needed.
+    essential_tags = "p, a, img, iframe, table, tr, th, td, h1, h2, h3, h4, h5, h6, ul, ol, li, em, strong, pre, code"
     values += [
       len(node.content),                         # html length
       len(doc.select("*")),                      # number of tags
+      len(doc.select(essential_tags)),           # number of essential tags (p, img, table, etc.)
       len(re.split("\s+", doc.text)),            # word count
       len(doc.select("h1, h2, h3, h4, h5, h6")), # number of headings
       len(doc.select("iframe")),                 # number of iframes
@@ -997,7 +1004,7 @@ class Bundle:
     # - the rows to be newline-delimited.
     return "\n".join([
       "\t".join([
-        str(value) for value in row
+        str(value).replace("`", "") for value in row
       ]) for row in rows
     ])
 
@@ -1041,14 +1048,12 @@ class Bundle:
         padding: 2px;
       }
 
+      /* this covers depth=3 or higher. */
+      [data-depth] { margin-left: 45px; }
+
+      [data-depth="0"] { margin-left: 0px; }
       [data-depth="1"] { margin-left: 15px; }
       [data-depth="2"] { margin-left: 30px; }
-      [data-depth="3"] { margin-left: 45px; }
-      [data-depth="4"] { margin-left: 60px; }
-      [data-depth="5"] { margin-left: 75px; }
-      [data-depth="6"] { margin-left: 90px; }
-      [data-depth="7"] { margin-left: 105px; }
-      [data-depth="8"] { margin-left: 120px; }
 
       iframe {
         flex-grow: 1;

--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -128,6 +128,20 @@ def clean_up_html(html):
     if not el.attrs or not el.attrs.get("style"):
       el.unwrap()
   
+  # remove empty blocks. for a block to be empty it has to meet all of these criteria:
+  #
+  #  - contain no visible text.
+  #  - contain either no tags, or only <br> tags.
+  #
+  # the second rule is important otherwise we'll remove paragraphs that contain only an image.
+  for el in doc.select("p, h1, h2, h3, h4, h5, h6"):
+    text = el.text.strip()
+    if not text:
+      tag_count = len(el.select("*"))
+      br_count = len(el.select("br"))
+      if tag_count == br_count:
+        el.decompose()
+
   return str(doc).replace("\\n", "\n").replace("\\'", "'")
 
 def traverse_tree(bundle, func, node=None, parent=None, depth=0, post=False, **kwargs):
@@ -146,17 +160,67 @@ def traverse_tree(bundle, func, node=None, parent=None, depth=0, post=False, **k
       if not node.parents:
         traverse_tree(bundle, func, node, post=post, **kwargs)
 
+def make_spreadsheet(node, parent, depth, rows):
+  # if the 'rows' list is empty, add the headings to it.
+  if not rows:
+    rows.append([
+      "Index",
+      "ID",
+      "External URL",
+      "Type",
+      "Title",
+      "HTML Length",
+      "# of HTML Tags",
+      "Word Count",
+      "Headings",
+      "Iframes",
+      "All Links",
+      "Guru Card Links",
+      "Guru File Links",
+      "Table Cells",
+      "All Images",
+      "Attached Images"
+    ])
+
+  indent = "    " * min(3, depth)
+  values = [
+    len(rows),
+    node.id,
+    node.url or "",
+    node.type,
+    '"' + indent + node.title + '"'
+  ]
+
+  # for nodes with content we put additional values in the sheet,
+  # like word count, # of headings, # of links, etc.
+  if node.type == CARD:
+    doc = BeautifulSoup(node.content, "html.parser")
+    values += [
+      len(node.content),                         # html length
+      len(doc.select("*")),                      # number of tags
+      len(re.split("\s+", doc.text)),            # word count
+      len(doc.select("h1, h2, h3, h4, h5, h6")), # number of headings
+      len(doc.select("iframe")),                 # number of iframes
+      len(doc.select("a[href]")),                # all links
+      len(doc.select('a[href^="cards/"]')),      # guru card links,
+      len(doc.select('a[href^="resources/"]')),  # guru file links,
+      len(doc.select("td")),                     # table cells
+      len(doc.select("img")),                    # images
+      len(doc.select('img[src^="resources/"]')), # attached images
+    ]
+
+  rows.append(values)
+
 def make_html_tree(node, parent, depth, html_pieces):
   """This builds the board/card tree in the HTML preview page."""
-  indent = "&nbsp;&nbsp;" * min(3, depth)
   if node.type == CARD:
     url = node.bundle.CARD_HTML_PATH % (node.bundle.id, node.id)
     html_pieces.append(
-      '<a href="%s" data-original-url="%s" target="iframe">%s%s (%s)</a>' % (url, node.url, indent, node.title, node.type)
+      '<a href="%s" data-depth="%s" data-original-url="%s" target="iframe">%s (%s)</a>' % (url, depth, node.url, node.title, node.type)
     )
   else:
     html_pieces.append(
-      '<div>%s%s (%s)</div>' % (indent, node.title, node.type)
+      '<div data-depth="%s">%s (%s)</div>' % (depth, node.title, node.type)
     )
 
 def print_node(node, parent, depth):
@@ -923,6 +987,20 @@ class Bundle:
       is_sync=is_sync
     )
   
+  def build_spreadsheet(self):
+    rows = []
+    traverse_tree(self, make_spreadsheet, rows=rows)
+
+    # after the traversal, rows is a list of lists. we have to convert:
+    # - the values to strings.
+    # - the values to tab-delimited rows.
+    # - the rows to be newline-delimited.
+    return "\n".join([
+      "\t".join([
+        str(value) for value in row
+      ]) for row in rows
+    ])
+
   def view_in_browser(self, open_browser=True):
     """
     This generates an HTML page that shows the .html files in an iframe
@@ -930,6 +1008,8 @@ class Bundle:
     """
     html_pieces = []
     traverse_tree(self, make_html_tree, html_pieces=html_pieces)
+
+    spreadsheet = self.build_spreadsheet()
     html = """<!doctype html>
 <html>
   <head>
@@ -951,16 +1031,25 @@ class Bundle:
 
       #tree {
         padding: 10px;
-        height: 100%%;
+        height: calc(100%% - 70px);
         overflow: auto;
         box-sizing: border-box;
-        padding-bottom: 30px;
         max-width: 400px;
       }
       #tree > * {
         display: block;
         padding: 2px;
       }
+
+      [data-depth="1"] { margin-left: 15px; }
+      [data-depth="2"] { margin-left: 30px; }
+      [data-depth="3"] { margin-left: 45px; }
+      [data-depth="4"] { margin-left: 60px; }
+      [data-depth="5"] { margin-left: 75px; }
+      [data-depth="6"] { margin-left: 90px; }
+      [data-depth="7"] { margin-left: 105px; }
+      [data-depth="8"] { margin-left: 120px; }
+
       iframe {
         flex-grow: 1;
         max-width: 734px;
@@ -985,10 +1074,24 @@ class Bundle:
         color: #fff;
       }
 
+      #copy-spreadsheet {
+        border: 0;
+        outline: 0;
+        background: #44f;
+        color: #fff;
+        font-weight: bold;
+        padding: 8px 12px;
+        position: fixed;
+        left: 20px;
+        bottom: 20px;
+        cursor: pointer;
+      }
+
     </style>
   </head>
   <body>
     <div id="tree">%s</div>
+    <button id="copy-spreadsheet">Copy Spreadsheet</button>
     <iframe name="iframe" src=""></iframe>
     <iframe id="source" style="display: none" src=""></iframe>
     <script>
@@ -1040,10 +1143,47 @@ class Bundle:
       };
       next();
 
+      var spreadsheet = `%s`;
+      var copyButton = document.getElementById("copy-spreadsheet");
+      var copyTimeout;
+      copyButton.onclick = function() {
+        var textarea = document.createElement("textarea");
+        textarea.value = spreadsheet;
+
+        // avoid scrolling to bottom.
+        textarea.style.top = "0";
+        textarea.style.left = "0";
+        textarea.style.position = "fixed";
+
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+
+        var successful = false;
+        try {
+            successful = document.execCommand("copy");
+        } catch (err) {
+        }
+
+        document.body.removeChild(textarea);
+
+        copyButton.innerHTML = "Spreadsheet Copied!";
+        if (copyTimeout) {
+          clearTimeout(copyTimeout);
+        }
+        copyTimeout = setTimeout(function() {
+          copyButton.innerHTML = "Copy Spreadsheet";
+        }, 1500);
+      };
+
+      if (!spreadsheet) {
+        copyButton.style.display = "none";
+      }
+
     </script>
   </body>
 </html>
-""" % "".join(html_pieces)
+""" % ("".join(html_pieces), spreadsheet)
 
     write_file(self.CARD_PREVIEW_PATH % self.id, html)
     if open_browser:

--- a/guru/core.py
+++ b/guru/core.py
@@ -812,6 +812,11 @@ class Guru:
       except:
         return None
 
+  def get_visible_cards(self):
+    url = "%s/search/visible" % self.base_url
+    response = self.__get(url)
+    return response.headers.get("x-guru-total-cards")
+
   def get_card_version(self, card, version):
     """
     Loads a previous version of a card.
@@ -1650,7 +1655,7 @@ class Guru:
     if not team_id:
       self.__log(make_red("couldn't find your Team ID, are you authenticated?"))
       return
-    
+
     url = "%s/teams/%s/analytics?fromDate=%s&toDate=%s" % (
       self.base_url,
       team_id,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -848,6 +848,7 @@ class TestBundle(unittest.TestCase):
 <br/>- Two
 
 </td>
+
 </tr></table>""")
 
   @use_guru()


### PR DESCRIPTION
There are a few changes here:

1. It adds a "copy spreadsheet" button to the import preview page. This generates and copies to the clipboard a table listing all the boards/cards and some metrics about each card (word count, # of headings, etc.).
2. Tries to identify and remove empty blocks, or ones that just contain a `<br>` and nothing else. Our editor puts good margins between elements and imported content often has extra line breaks that we don't need.
3. Add `get_visible_cards()` which uses the response headers to see how many cards you have read access (or higher) to.
4. Add example/find_external_images.py