### PR TITLE
updates to the Publisher class

### DIFF
--- a/guru/publish.py
+++ b/guru/publish.py
@@ -10,7 +10,7 @@ def is_successful(result):
   result could either be a boolean or the response object.
   """
   if isinstance(result, requests.models.Response):
-    return int(response.status_code / 100) == 2
+    return int(result.status_code / 100) == 2
   else:
     return result
 

--- a/run.sh
+++ b/run.sh
@@ -8,13 +8,19 @@ test)
   fi
   ;;
 all)
-  E2E=true coverage run -m unittest && coverage report && coverage html
+  PUB=true E2E=true coverage run -m unittest && coverage report && coverage html
   if [ "$2" = "-v" ]; then
     open htmlcov/index.html
   fi
   ;;
 e2e)
   E2E=true coverage run -m unittest tests.test_e2e && coverage report && coverage html
+  if [ "$2" = "-v" ]; then
+    open htmlcov/index.html
+  fi
+  ;;
+pub)
+  PUB=true coverage run -m unittest tests.test_publish && coverage report && coverage html
   if [ "$2" = "-v" ]; then
     open htmlcov/index.html
   fi
@@ -30,7 +36,8 @@ docs)
   echo ""
   echo "  test -- to run only unit tests"
   echo "  e2e -- to run only end-to-end tests"
-  echo "  all -- to run unit and end-to-end tests"
+  echo "  pub -- to run only publishing tests"
+  echo "  all -- to run unit, end-to-end, and publishing tests"
   echo "  docs -- to generate documentation"
   echo ""
   echo "When running tests, use -v to open the coverage report in your browser."


### PR DESCRIPTION
1. Implements the `find_external_*` methods for all object types.
2. Adds a `dry_run` flag, when true it won't call any of the `create_external_*` or `update_external_*` methods so you can test a script without publishing changes by accident.
3. Lets `update_external_*` methods return a boolean or response object that's used to indicate if the update was successful. The Publisher class will only update its metadata if the update was successful.