### PR TITLE
make the bundle object have methods for http calls

### DIFF
--- a/examples/wikipedia_sync1.py
+++ b/examples/wikipedia_sync1.py
@@ -29,7 +29,7 @@ my_favorite_albums = bundle.node(id="albums", title="My Favorite Albums")
 for url in urls:
   # download the page from wikipedia and extract the article's body and title
   # since that's the information we need to make a guru card.
-  doc = guru.load_html(url)
+  doc = bundle.load_html(url)
   body = doc.select(".mw-parser-output")[0]
   title = doc.find(id="firstHeading").text
 

--- a/examples/wikipedia_sync2.py
+++ b/examples/wikipedia_sync2.py
@@ -7,8 +7,8 @@ import guru
 # 2. we download images from wikipedia so the resulting guru cards have their
 #    images hosted in guru, rather than referencing the external images.
 
-def get_page(url, include_image=True):
-  doc = guru.load_html(url)
+def get_page(bundle, url, include_image=True):
+  doc = bundle.load_html(url)
 
   # remove elements we don't want in the guru card (right column, footer links, etc.)
   body = doc.select(".mw-parser-output")[0]
@@ -32,9 +32,9 @@ def get_page(url, include_image=True):
 # and, if we should, it goes ahead and downloads it. if you're working with an
 # external system that requires authentication, you may need to add a header to
 # the download_file() call so it's able to access the file.
-def download_file(url, filename):
+def download_file(url, filename, bundle, node):
   if "upload.wikimedia.org" in url:
-    return guru.download_file(url, filename)
+    return bundle.download_file(url, filename)
 
 # these are the urls of the pages we're going to download and turn into guru cards.
 # the cards will be grouped by decade, so the decade labels become sections.
@@ -75,12 +75,12 @@ for era in sorted(albums.keys()):
   section = bundle.node(id=era, title=era).add_to(albums_board)
 
   for url in albums[era]:
-    node = get_page(url)
+    node = get_page(bundle, url)
     node.tags = [era, "album"]
     node.add_to(section)
 
 for url in musicians:
-  get_page(url).add_to(musicians_board)
+  get_page(bundle, url).add_to(musicians_board)
 
 bundle.zip(download_func=download_file)
 bundle.view_in_browser()

--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -16,7 +16,7 @@ if sys.version_info.major >= 3:
 else:
   from urlparse import urljoin
 
-from guru.util import clear_dir, write_file, copy_file, download_file, to_yaml
+from guru.util import clear_dir, write_file, copy_file, download_file, to_yaml, http_post, http_get, load_html
 
 # node types
 NONE = "NONE"
@@ -581,7 +581,7 @@ class BundleNode:
           self.bundle.log(message="checking if we should download attachment", url=absolute_url, file=filename)
 
           # returning True means the file was downloaded so we need to update the src/href.
-          if download_func(absolute_url, filename):
+          if download_func(absolute_url, filename, self.bundle, self):
             self.bundle.log(message="download successful", url=absolute_url, file=filename)
             self.bundle.resources[resource_id] = filename
             element.attrs[attr] = "resources/%s" % resource_id
@@ -843,6 +843,26 @@ class Bundle:
       traverse_tree(self, print_type)
     else:
       traverse_tree(self, print_node)
+
+  def load_html(self, url, cache=False, make_links_absolute=True, headers=None):
+    # todo: figure out if we should log the headers. these could be helpful to have later
+    #       but they could also contain an API key or other sensitive data.
+    self.log(message="calling load_html", url=url, cache=cache, make_links_absolute=make_links_absolute)
+    return load_html(url, cache, make_links_absolute, headers)
+
+  def http_get(self, url, cache=False, headers=None, timeout=0):
+    self.log(message="calling http_get", url=url, cache=cache, timeout=timeout)
+    return http_get(url, cache, headers)
+
+  def http_post(self, url, data=None, cache=False, headers=None, timeout=0):
+    self.log(message="calling http_post", url=url, cache=cache, timeout=timeout)
+    return http_post(url, data, cache, headers)
+
+  def download_file(self, url, filename, headers=None):
+    self.log(message="calling download_file", url=url, filename=filename)
+    status_code, file_size = download_file(url, filename, headers)
+    self.log(message="download complete", url=url, filename=filename, status_code=status_code, file_size=file_size)
+    return status_code, file_size
 
   """
   def download_resource(self, url, headers=None):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -684,7 +684,9 @@ class TestBundle(unittest.TestCase):
 
     self.assertEqual(download_mock.call_args.args, (
       "https://www.example.com/test.png",
-      "/tmp/test_sync_with_image_we_download/resources/a3957e37ef2bcbe40ae4cfa69d8a2e5e.png"
+      "/tmp/test_sync_with_image_we_download/resources/a3957e37ef2bcbe40ae4cfa69d8a2e5e.png",
+      sync,
+      node1
     ))
     self.assertEqual(read_yaml("/tmp/test_sync_with_image_we_download/collection.yaml"), {
       "Title": "test",
@@ -715,7 +717,9 @@ class TestBundle(unittest.TestCase):
 
     self.assertEqual(download_mock.call_args.args, (
       "https://www.example.com/test.png",
-      "/tmp/test_sync_with_image_we_dont_download/resources/a3957e37ef2bcbe40ae4cfa69d8a2e5e.png"
+      "/tmp/test_sync_with_image_we_dont_download/resources/a3957e37ef2bcbe40ae4cfa69d8a2e5e.png",
+      sync,
+      node1
     ))
     self.assertEqual(read_yaml("/tmp/test_sync_with_image_we_dont_download/collection.yaml"), {
       "Title": "test",
@@ -745,7 +749,9 @@ class TestBundle(unittest.TestCase):
 
     self.assertEqual(download_mock.call_args.args, (
       "https://www.example.com/test.pdf",
-      "/tmp/test_sync_with_attachment_we_download/resources/f7046e184217c5391c01550389ee7406.pdf"
+      "/tmp/test_sync_with_attachment_we_download/resources/f7046e184217c5391c01550389ee7406.pdf",
+      sync,
+      node1
     ))
     self.assertEqual(read_yaml("/tmp/test_sync_with_attachment_we_download/collection.yaml"), {
       "Title": "test",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,5 +1,6 @@
 
 import unittest
+import requests
 
 from tests.util import use_guru
 
@@ -500,6 +501,16 @@ class TestEndToEnd(unittest.TestCase):
       "user": "rmiller@getguru.com",
       "eventDate": "2020-09-14T19:54:44.096+0000"
     })
+
+  @use_guru(SDK_E2E_USER, SDK_E2E_TOKEN)
+  def test_upload_file(self, g):
+    # write a local text file then try uploading it.
+    guru.write_file("/tmp/upload.txt", "sample file")
+    guru_url = g.upload_file("/tmp/upload.txt")
+
+    # download the file to check that it worked.
+    response = requests.get(guru_url, auth=(SDK_E2E_USER, SDK_E2E_TOKEN))
+    self.assertEqual(response.content.decode("utf-8"), "sample file")
 
 # these are the methods that aren't tested yet:
 # add_users_to_group

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,7 +71,7 @@ class TestUtil(unittest.TestCase):
     self.assertEqual(post1, "post1")
 
     responses.add(responses.POST, "https://www.example.com/post2", body="post2")
-    post2 = guru.http_post("https://www.example.com/post2", data=["a"], cache=True)
+    post2 = guru.http_post("https://www.example.com/post2", data=["a"], cache=False)
     self.assertEqual(post2, "post2")
 
     # make the same call again but since cache=True, it won't make a call.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,35 +14,42 @@ def read_html(filename):
 
 
 class TestUtil(unittest.TestCase):
+  @use_guru()
   @responses.activate
-  def test_load_html(self):
+  def test_load_html(self, g):
     # register the response for the API call we'll make.
     responses.add(responses.GET, "https://www.example.com/test/index.html", body="""<p>
   <a href="../page.html">link</a>
   <img src="test.png" />
 </p>""")
 
-    doc = guru.load_html("https://www.example.com/test/index.html")
+    bundle = g.bundle("http")
+    doc = bundle.load_html("https://www.example.com/test/index.html")
     self.assertEqual(doc.find("a").attrs["href"], "https://www.example.com/page.html")
     self.assertEqual(doc.find("img").attrs["src"], "https://www.example.com/test/test.png")
 
     # load it again with caching and assert that we still only made one call.
-    guru.load_html("https://www.example.com/test/index.html", cache=True)
+    bundle.load_html("https://www.example.com/test/index.html", cache=True)
     self.assertEqual(get_calls(), [{
       "method": "GET",
       "url": "https://www.example.com/test/index.html"
     }])
 
+  @use_guru()
   @responses.activate
-  def test_load_html_with_local_file(self):
-    doc = guru.load_html("./tests/test_sync_with_local_files_node1.html")
+  def test_load_html_with_local_file(self, g):
+    bundle = g.bundle("http")
+    doc = bundle.load_html("./tests/test_sync_with_local_files_node1.html")
     self.assertEqual(doc.find("img").attrs["src"], "tests/test_sync_with_local_files_test.png")
 
+  @use_guru()
   @responses.activate
-  def test_download_file(self):
+  def test_download_file(self, g):
+    bundle = g.bundle("http")
+
     html = "<p>test</p>"
     responses.add(responses.GET, "https://www.example.com/example.html", body=html)
-    guru.download_file("https://www.example.com/example.html", "./tests/example.html")
+    bundle.download_file("https://www.example.com/example.html", "./tests/example.html")
     self.assertEqual(read_html("./tests/example.html"), html)
 
   def test_edge_cases(self):
@@ -50,37 +57,43 @@ class TestUtil(unittest.TestCase):
     guru.read_file("/tmp/this_does_not_exist")
     guru.copy_file("/tmp/this_does_not_exist/a", "/tmp/this_does_not_exist/b")
 
+  @use_guru()
   @responses.activate
-  def test_character_encoding_edge_cases(self):
+  def test_character_encoding_edge_cases(self, g):
+    bundle = g.bundle("http")
+
     responses.add(responses.GET, "https://www.example.com/test1", body="test1")
-    test1 = guru.http_get("https://www.example.com/test1", cache=False)
+    test1 = bundle.http_get("https://www.example.com/test1", cache=False)
     self.assertEqual(test1, "test1")
 
     responses.add(responses.GET, "https://www.example.com/test2", body="Yes 👍")
-    test2 = guru.http_get("https://www.example.com/test2", cache=False)
+    test2 = bundle.http_get("https://www.example.com/test2", cache=False)
     self.assertEqual(test2, "Yes 👍")
 
     responses.add(responses.GET, "https://www.example.com/test3", body="háček señor Chișinău")
-    test3 = guru.http_get("https://www.example.com/test3", cache=False)
+    test3 = bundle.http_get("https://www.example.com/test3", cache=False)
     self.assertEqual(test3, "háček señor Chișinău")
 
   def test_format_timestamp(self):
     self.assertEqual(guru.format_timestamp("2021-03-01"), "2021-03-01T00:00:00-00:00")
     self.assertEqual(guru.format_timestamp("2021-03-01T01:23:45"), "2021-03-01T01:23:45-00:00")
 
+  @use_guru()
   @responses.activate
-  def test_http_post(self):
+  def test_http_post(self, g):
+    bundle = g.bundle("http")
+
     responses.add(responses.POST, "https://www.example.com/post1", body="post1")
-    post1 = guru.http_post("https://www.example.com/post1", data={}, cache=False)
+    post1 = bundle.http_post("https://www.example.com/post1", data={}, cache=False)
     self.assertEqual(post1, "post1")
 
     responses.add(responses.POST, "https://www.example.com/post2", body="post2")
-    post2 = guru.http_post("https://www.example.com/post2", data=["a"], cache=False)
+    post2 = bundle.http_post("https://www.example.com/post2", data=["a"], cache=False)
     self.assertEqual(post2, "post2")
 
     # make the same call again but since cache=True, it won't make a call.
     responses.add(responses.POST, "https://www.example.com/post2", body="post2")
-    post2 = guru.http_post("https://www.example.com/post2", data=["a"], cache=True)
+    post2 = bundle.http_post("https://www.example.com/post2", data=["a"], cache=True)
     self.assertEqual(post2, "post2")
 
     self.assertEqual(get_calls(), [{
@@ -91,4 +104,49 @@ class TestUtil(unittest.TestCase):
       "method": "POST",
       "url": "https://www.example.com/post2",
       "body": ["a"]
+    }])
+
+  @use_guru()
+  @responses.activate
+  def test_429_responses(self, g):
+    bundle = g.bundle("http")
+
+    # we set this up so each endpoint gets a 429 the first time and a 200 the second time.
+    responses.add(responses.GET, "https://www.example.com/http_get", status=429)
+    responses.add(responses.GET, "https://www.example.com/http_get", status=200, body="test")
+    responses.add(responses.GET, "https://www.example.com/load_html", status=429)
+    responses.add(responses.GET, "https://www.example.com/load_html", status=200, body="test")
+    responses.add(responses.GET, "https://www.example.com/download_file", status=429)
+    responses.add(responses.GET, "https://www.example.com/download_file", status=200, body="test")
+    responses.add(responses.POST, "https://www.example.com/http_post", status=429)
+    responses.add(responses.POST, "https://www.example.com/http_post", status=200, body="test")
+
+    response = bundle.http_get("https://www.example.com/http_get", wait=0.1)
+    response = bundle.load_html("https://www.example.com/load_html", wait=0.1)
+    response = bundle.download_file("https://www.example.com/download_file", "./tests/download_file.html", wait=0.1)
+    response = bundle.http_post("https://www.example.com/http_post", wait=0.1)
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://www.example.com/http_get"
+    }, {
+      "method": "GET",
+      "url": "https://www.example.com/http_get"
+    }, {
+      "method": "GET",
+      "url": "https://www.example.com/load_html"
+    }, {
+      "method": "GET",
+      "url": "https://www.example.com/load_html"
+    }, {
+      "method": "GET",
+      "url": "https://www.example.com/download_file"
+    }, {
+      "method": "GET",
+      "url": "https://www.example.com/download_file"
+    }, {
+      "method": "POST",
+      "url": "https://www.example.com/http_post"
+    }, {
+      "method": "POST",
+      "url": "https://www.example.com/http_post"
     }])


### PR DESCRIPTION
Routing HTTP calls through the 'bundle' object means it can log all calls that are made. Everything it logs is written to a .csv file so having all the HTTP calls automatically logged there will be helpful for debugging.