### PR TITLE
Feature/johnchappelle/ch54019/add filenotfound exception handling to copy

### DIFF
--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -319,16 +319,9 @@ def insert_nodes(node, parent, depth):
   # board groups that have content require two new nodes -- one for the
   # card and one to be the board that contains that card.
   if node.content and node.type == BOARD_GROUP:
-    # insert a board and add a card to it.
-    board_id = "%s_content_board" % node.id
+    # Add a card to the first board in the board group.
     content_id = "%s_content" % node.id
-    board_node = bundle.node(
-      id=board_id,
-      url=node.url,
-      title="%s Content" % node.title,
-      type=BOARD
-    )
-    node.add_child(board_node, first=True)
+    board_id = node.children[0]
 
     content_node = bundle.node(
       id=content_id,
@@ -337,7 +330,7 @@ def insert_nodes(node, parent, depth):
       content=node.content,
       type=CARD
     )
-    bundle.node(board_id).add_child(content_node)
+    bundle.node(board_id).add_child(content_node, first=True)
 
   # if the node has content and is a board or section we just make
   # a new node (as the card) inside this node.

--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -47,6 +47,8 @@ def _is_local(url_or_path):
     return False
   elif url_or_path.startswith("//"):
     return False
+  elif re.match(r'[a-zA-Z]{1,}\:\/\/.*', url_or_path):
+    return False
   else:
     return True
 

--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -318,8 +318,8 @@ def insert_nodes(node, parent, depth):
   
   bundle = node.bundle
 
-  # board groups that have content require two new nodes -- one for the
-  # card and one to be the board that contains that card.
+  # board groups have to have a board as a child to be a board group, 
+  # so if it has content, we can add it to the first board in the group
   if node.content and node.type == BOARD_GROUP:
     # Add a card to the first board in the board group.
     content_id = "%s_content" % node.id

--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -47,7 +47,7 @@ def _is_local(url_or_path):
     return False
   elif url_or_path.startswith("//"):
     return False
-  elif re.match(r'[a-zA-Z]{1,}\:\/\/.*', url_or_path):
+  elif not url_or_path.startswith("file:") and re.match(r'[a-zA-Z]{1,}\:\/\/.*', url_or_path):
     return False
   else:
     return True

--- a/guru/util.py
+++ b/guru/util.py
@@ -141,7 +141,10 @@ def copy_file(src, dest):
 
   try:
     make_dir(dest)
-    shutil.copyfile(src, dest)
+    try:
+      shutil.copyfile(src, dest)
+    except FileNotFoundError:
+      raise FileNotFoundError("File not found", src)
     return True
   except:
     return False


### PR DESCRIPTION
CH story: https://app.clubhouse.io/guru/story/54019/add-filenotfound-exception-handling-to-copy-file-add-card-node-to-first-board-in-boardgroup-in-bundle-py

## Overview

This PR adds handling for a FileNotFoundError exception in `guru.util.copy_file`. Previously, when trying to copy from a file path that doesn't exist, an unhandled exception was thrown, so now this will explicitly handle this exception.

Also added a check to `_is_local` in `bundle.py` to return False if a url or path starts with `{something}://`. When running a migration, a url pattern like this slipped through as local, so wanted to add this check. ***Update***: will be adding a check that the url doesn't start with `file://`, as that would be local.

In addition, in `bundle.py`, instead of inserting a new board in a boardgroup when adding a card to it, this PR makes a change that adds the card to the first board in the group, as a boardgroup would contain a board, by definition.
