### PR TITLE
updates to bundle

### DIFF
--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -825,7 +825,7 @@ class Bundle:
   That'll create a bundle with one card and upload it to the collection
   called "Import Test" -- if that collection doesn't exist, it'll be created.
   """
-  def __init__(self, guru, id="", clear=False, folder="/tmp/", verbose=False, skip_empty_sections=True):
+  def __init__(self, guru, id="", clear=False, folder="/tmp/", verbose=False, skip_empty_sections=False):
     self.guru = guru
     self.id = slugify(id) if id else str(int(time.time()))
     self.nodes = []

--- a/guru/core.py
+++ b/guru/core.py
@@ -2196,17 +2196,17 @@ class Guru:
     response = self.__put(url, data)
     return status_to_bool(response.status_code)
 
-  def bundle(self, id="default", clear=True, folder="/tmp/", verbose=False):
+  def bundle(self, id="default", clear=True, folder="/tmp/", verbose=False, skip_empty_sections=False):
     """
     Creates a Bundle object that can be used to bulk import content.
     """
-    return Bundle(guru=self, id=id, clear=clear, folder=folder, verbose=verbose)
+    return Bundle(guru=self, id=id, clear=clear, folder=folder, verbose=verbose, skip_empty_sections=skip_empty_sections)
   
-  def sync(self, id="default", clear=True, folder="/tmp/", verbose=False):
+  def sync(self, id="default", clear=True, folder="/tmp/", verbose=False, skip_empty_sections=False):
     """
     internal: sync() is an alias for bundle().
     """
-    return Bundle(guru=self, id=id, clear=clear, folder=folder, verbose=verbose)
+    return Bundle(guru=self, id=id, clear=clear, folder=folder, verbose=verbose, skip_empty_sections=skip_empty_sections)
 
   def get_events(self, start="", end="", max_pages=10):
     """

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -507,20 +507,18 @@ class TestBundle(unittest.TestCase):
         "Title": "node 3",
         "Type": "section",
         "Items": [{
-          "ID": "4",
-          "Type": "card"
-        }, {
           "ID": "5",
           "Type": "card"
         }]
       }]
     })
-    self.assertEqual(read_yaml("/tmp/test_sync_with_five_nodes/cards/4.yaml"), {
-      "ExternalId": "4",
-      "ExternalUrl": "https://www.example.com/4",
-      "Title": "node 4"
-    })
-    self.assertEqual(read_html("/tmp/test_sync_with_five_nodes/cards/4.html"), "")
+
+    # node 4 doesn't get included in the zip because its parent, node 3, is a section.
+    # that means node 4 has to be a card but it has no content, so we don't make a blank card.
+    with self.assertRaises(FileNotFoundError):
+      read_html("/tmp/test_sync_with_five_nodes/cards/4.html")
+    with self.assertRaises(FileNotFoundError):
+      read_html("/tmp/test_sync_with_five_nodes/cards/4.yaml")
 
     self.assertEqual(read_yaml("/tmp/test_sync_with_five_nodes/cards/5.yaml"), {
       "ExternalId": "5",
@@ -570,20 +568,18 @@ class TestBundle(unittest.TestCase):
         "Title": "node 3",
         "Type": "section",
         "Items": [{
-          "ID": "4",
-          "Type": "card"
-        }, {
           "ID": "5",
           "Type": "card"
         }]
       }]
     })
-    self.assertEqual(read_yaml("/tmp/test_sync_with_five_nodes_and_favor_sections/cards/4.yaml"), {
-      "ExternalId": "4",
-      "ExternalUrl": "https://www.example.com/4",
-      "Title": "node 4"
-    })
-    self.assertEqual(read_html("/tmp/test_sync_with_five_nodes_and_favor_sections/cards/4.html"), "")
+
+    # node 4 doesn't get included in the zip because its parent, node 3, is a section.
+    # that means node 4 has to be a card but it has no content, so we don't make a blank card.
+    with self.assertRaises(FileNotFoundError):
+      read_html("/tmp/test_sync_with_five_nodes/cards/4.html")
+    with self.assertRaises(FileNotFoundError):
+      read_html("/tmp/test_sync_with_five_nodes/cards/4.yaml")
 
     self.assertEqual(read_yaml("/tmp/test_sync_with_five_nodes_and_favor_sections/cards/5.yaml"), {
       "ExternalId": "5",


### PR DESCRIPTION
1. We may have empty cards that have children who aren't empty, so we need the empty card to exist in the hierarchy so when we traverse the tree, we still reach those non-empty children. But, we don't want these empty card nodes to actually get included in the zip, so we use the `removed` flag to indicate it's a card that still exists but should be treated like it's not there.
2. Adds an option to exclude empty sections. When you end up with a lot of empty cards, you're likely to end up with empty sections and this'll make sure those don't get included in the zip.
3. When we resolve links by comparing a URL to known external URLs, we assumed they'd always be card links but they could be board links.