### PR TITLE
Feature/johnchappelle/ch53593/find and replace preview utility for the

### DIFF
--- a/guru/__init__.py
+++ b/guru/__init__.py
@@ -35,3 +35,13 @@ from guru.util import (
   clear_dir,
   format_timestamp
 )
+
+from guru.find_and_replace import (
+  get_term_count,
+  add_highlight,
+  replace_text_in_text,
+  replace_text_in_html,
+  replace_text_in_card, 
+  Preview, 
+  PreviewData
+)

--- a/guru/find_and_replace.py
+++ b/guru/find_and_replace.py
@@ -5,6 +5,11 @@ from guru.data_objects import Card
 
 from bs4 import BeautifulSoup
 
+# for markdown_div in card.doc.select("[data-ghq-card-content-markdown-content]"):
+#       md = unquote(markdown_div.attrs.get("data-ghq-card-content-markdown-content"))
+#       html = markdown.markdown(md)
+#       doc = BeautifulSoup(html, "html.parser")
+
 def get_term_count(text, term):
   doc = BeautifulSoup(text, "html.parser")
   lowered_doc = doc.text.lower()
@@ -46,7 +51,7 @@ def replace_text_in_html(html, term, replacement, case_sensitive=False):
     ))
   return str(doc)
 
-def add_highlight(card, term, replacement, highlight="replacement"):
+def add_highlight(card, term, replacement, highlight="replacement", case_sensitive=False):
   highlight_class = None
   if highlight == "original":
     highlight_class = "sdk-orig-highlight"
@@ -55,7 +60,7 @@ def add_highlight(card, term, replacement, highlight="replacement"):
 
   card_content = card.content if isinstance(card, Card) else card
 
-  content = replace_text_in_html(card_content, term, "[GURU_SDK_HIGHLIGHT_START]%s[GURU_SDK_HIGHLIGHT_END]" % replacement)
+  content = replace_text_in_html(card_content, term, "[GURU_SDK_HIGHLIGHT_START]%s[GURU_SDK_HIGHLIGHT_END]" % replacement, case_sensitive=case_sensitive)
   # do string replacements on the [start] and [end] tokens.
   if isinstance(card, Card):
     content = replace_text_in_html(content, "[GURU_SDK_HIGHLIGHT_START]", '<span class=%s>' % highlight_class, case_sensitive=True)
@@ -68,21 +73,21 @@ def add_highlight(card, term, replacement, highlight="replacement"):
 def replace_text_in_card(card, term, replacement, replace_title=True, replacement_highlight=False, orig_highlight=False, case_sensitive=False):
   if isinstance(card, Card):
     if replace_title:
-      card.title = replace_text_in_text(card.title, term, replacement)
+      card.title = replace_text_in_text(card.title, term, replacement, case_sensitive=case_sensitive)
     if replacement_highlight:
-      card.content = add_highlight(card, term, replacement)
+      card.content = add_highlight(card, term, replacement, case_sensitive=case_sensitive)
     elif orig_highlight:
-      card.content = add_highlight(card, term, replacement, highlight="original")
+      card.content = add_highlight(card, term, replacement, highlight="original", case_sensitive=case_sensitive)
     else:
-      card.content = replace_text_in_html(card.content, term, replacement)
+      card.content = replace_text_in_html(card.content, term, replacement, case_sensitive=case_sensitive)
     return card.content
   else:
     if replacement_highlight:
-      card = add_highlight(card, term, replacement)
+      card = add_highlight(card, term, replacement, case_sensitive=case_sensitive)
     elif orig_highlight:
-      card = add_highlight(card, term, replacement, highlight="original")
+      card = add_highlight(card, term, replacement, highlight="original", case_sensitive=case_sensitive)
     else:
-      card = replace_text_in_html(card, term, replacement)
+      card = replace_text_in_html(card, term, replacement, case_sensitive=case_sensitive)
     return card
 class PreviewData:
   def __init__(self, card, term, replacement, orig_content, new_content):

--- a/guru/find_and_replace.py
+++ b/guru/find_and_replace.py
@@ -3,7 +3,7 @@ import webbrowser
 from guru.util import write_file, load_html
 from guru.data_objects import Card
 
-
+from urllib.parse import quote
 from bs4 import BeautifulSoup
 
 # for markdown_div in card.doc.select("[data-ghq-card-content-markdown-content]"):
@@ -67,6 +67,7 @@ def replace_text_in_html(html, term, replacement, term_case_sensitive=False, rep
   return str(doc)
 
 def add_highlight(card, term, replacement, highlight="replacement", case_sensitive=False):
+  ## TODO: change functionality to accept just a term or replacement, and throw exception if neither are provided
   highlight_class = None
   if highlight == "original":
     highlight_class = "sdk-orig-highlight"

--- a/guru/find_and_replace.py
+++ b/guru/find_and_replace.py
@@ -76,13 +76,10 @@ def add_highlight(card, term, replacement, highlight="replacement", case_sensiti
   card_content = card.content if isinstance(card, Card) else card
 
   content = replace_text_in_html(card_content, term, "[GURU_SDK_HIGHLIGHT_START]%s[GURU_SDK_HIGHLIGHT_END]" % replacement, term_case_sensitive=case_sensitive)
+  
   # do string replacements on the [start] and [end] tokens.
-  if isinstance(card, Card):
-    content = replace_text_in_html(content, "[GURU_SDK_HIGHLIGHT_START]", '<span class=%s>' % highlight_class, term_case_sensitive=True, replacement_case_sensitive=True)
-    content = replace_text_in_html(content, "[GURU_SDK_HIGHLIGHT_END]", "</span>", term_case_sensitive=True, replacement_case_sensitive=True)
-  else:
-    content = replace_text_in_text(str(content), "[GURU_SDK_HIGHLIGHT_START]", '<span class=%s>' % highlight_class, replacement_case_sensitive=True)
-    content = replace_text_in_text(str(content), "[GURU_SDK_HIGHLIGHT_END]", "</span>", replacement_case_sensitive=True)
+  content = replace_text_in_text(str(content), "[GURU_SDK_HIGHLIGHT_START]", '<span class="%s">' % highlight_class, replacement_case_sensitive=True)
+  content = replace_text_in_text(str(content), "[GURU_SDK_HIGHLIGHT_END]", "</span>", replacement_case_sensitive=True)
   return content
 
 def replace_text_in_card(card, term, replacement, replace_title=True, replacement_highlight=False, orig_highlight=False, case_sensitive=False):

--- a/guru/find_and_replace.py
+++ b/guru/find_and_replace.py
@@ -1,0 +1,253 @@
+import re
+import webbrowser
+from guru.util import write_file, load_html
+from guru.data_objects import Card
+
+from bs4 import BeautifulSoup
+
+def replace_text_in_text(text, term, replacement, case_sensitive=False):
+  # replacement = "[start]Customer[end]".capitalize()
+  lowercased_term = term.lower()
+  lowercased_replacement = replacement.lower().replace("[guru_sdk_highlight_start]", "[GURU_SDK_HIGHLIGHT_START]").replace("[guru_sdk_highlight_end]", "[GURU_SDK_HIGHLIGHT_END]")
+  uppercased_term = term.upper()
+  uppercased_replacement = replacement.upper()
+  capitalized_term = term.capitalize()
+  if "[GURU_SDK_HIGHLIGHT_START]" in replacement:
+    replacement = replacement.replace("[GURU_SDK_HIGHLIGHT_START]", "")
+    capitalized_replacement = "[GURU_SDK_HIGHLIGHT_START]" + replacement.capitalize()
+  elif "[GURU_SDK_HIGHLIGHT_END]" in replacement:
+    replacement = replacement.replace("[GURU_SDK_HIGHLIGHT_END]", "")
+    capitalized_replacement = "[GURU_SDK_HIGHLIGHT_END]" + replacement.capitalize()
+
+
+  else:
+    capitalized_replacement = replacement.capitalize()
+  if case_sensitive:
+    text = text.replace(term, replacement)
+    print(case_sensitive, term, replacement)
+  else:
+    text = text.replace(lowercased_term, lowercased_replacement).replace(uppercased_term, uppercased_replacement).replace(capitalized_term, capitalized_replacement)
+  
+  return text
+
+def replace_text_in_html(html, term, replacement, case_sensitive=False):
+  doc = html if isinstance(html, BeautifulSoup) else BeautifulSoup(html, "html.parser")
+  pattern = re.compile(r'%s' % term, re.IGNORECASE)
+  text_nodes = doc.find_all(text=pattern)
+  for text_node in text_nodes:
+    text_node.replace_with(replace_text_in_text(
+      text_node, term, replacement, case_sensitive
+    ))
+  return str(doc)
+
+def replace_text_in_card(card, term, replacement, replace_title=True, highlight=False, case_sensitive=False):
+  if isinstance(card, Card):
+    if replace_title:
+      card.title = replace_text_in_text(card.title, term, replacement)
+    if highlight:
+      card.content = replace_text_in_html(card.content, term, "[GURU_SDK_HIGHLIGHT_START]%s[GURU_SDK_HIGHLIGHT_END]" % replacement)
+      # do string replacements on the [start] and [end] tokens.
+      card.content = replace_text_in_html(card.content, "[GURU_SDK_HIGHLIGHT_START]", '<span class="sdk-highlight">', case_sensitive=True)
+      card.content = replace_text_in_html(card.content, "[GURU_SDK_HIGHLIGHT_END]", "</span>", case_sensitive=True)
+    else:
+      card.content = replace_text_in_html(card.content, term, replacement)
+    return card.content
+  else:
+    if highlight:
+      card = replace_text_in_html(card, term, "[GURU_SDK_HIGHLIGHT_START]%s[GURU_SDK_HIGHLIGHT_END]" % replacement)
+      # do string replacements on the [start] and [end] tokens.
+      # card = replace_text_in_text(str(card), "[GURU_SDK_HIGHLIGHT_START]", '<span class="sdk-highlight">', case_sensitive=True)
+      # card = replace_text_in_text(str(card), "[GURU_SDK_HIGHLIGHT_END]", "</span>", case_sensitive=True)
+    else:
+      card = replace_text_in_html(card, term, replacement)
+    return card
+class PreviewData:
+  def __init__(self, card, orig_content, new_content):
+    self.card_id = card.id
+    self.title = card.title
+    self.orig_content = orig_content
+    self.new_content = new_content
+
+class Preview:
+  def __init__(self, content_list, term, replacement, folder="/tmp/", task_name=None):
+    self.content_list = content_list
+    self.term = term
+    self.replacement = replacement
+    self.task_name = task_name if task_name else "find_and_replace"
+    self.orig_content_path = folder + "%s/old_content/orig_%s.html"
+    self.new_content_path = folder + "%s/new_content/new_%s.html"
+    self.card_preview_path = folder + "%s/index.html"
+    self.html_pieces = []
+
+  def make_html_tree(self):
+    """This builds the original content/new content link in the HTML preview page."""
+    for content_data in self.content_list:
+      orig_filepath = self.orig_content_path % (self.task_name, content_data.card_id)
+      new_filepath = self.new_content_path % (self.task_name, content_data.card_id)
+
+      highlight_css = """
+      <style>
+
+      * {
+        color: rgba(0, 0, 0, 0.6)
+      }
+
+      .sdk-highlight {
+        background-color: #4a7; 
+        color: #fff;
+      }
+      </style>
+      """
+
+      
+
+      write_file(orig_filepath, content_data.orig_content)
+      write_file(new_filepath, content_data.new_content)
+      
+      # orig_content_html = load_html(orig_filepath, make_links_absolute=False)
+      # orig_content_html = replace_text_in_card(orig_content_html, self.term, self.term, replace_title=False, highlight=True)
+      # write_file(orig_filepath, highlight_css + str(orig_content_html))
+      
+      new_content_html = load_html(new_filepath, make_links_absolute=False)
+      new_content_html = replace_text_in_card(new_content_html, self.replacement, self.replacement, replace_title=False, highlight=True)
+      write_file(new_filepath, highlight_css + str(new_content_html))
+      
+      self.html_pieces.append(
+        '<a href="%s" data-original-url="%s" target="iframe">%s</a>' % (new_filepath, orig_filepath, content_data.title)
+      )
+
+  def view_in_browser(self, open_browser=True):
+      """
+      This generates an HTML page that shows the .html files in an iframe
+      so you can visualize the content structure and preview the HTML.
+      """
+
+      html = """<!doctype html>
+  <html>
+    <head>
+      <style>
+
+        body {
+          display: flex;
+          flex-direction: row;
+          margin: 0;
+          position: fixed;
+          left: 0;
+          right: 0;
+          top: 0;
+          bottom: 0;
+          font-family: arial, sans-serif;
+          font-size: 12px;
+          background: #f7f8fa;
+        }
+
+        #tree {
+          padding: 10px;
+          height: calc(100%% - 70px);
+          overflow: auto;
+          box-sizing: border-box;
+          max-width: 400px;
+        }
+        #tree > * {
+          display: block;
+          padding: 2px;
+        }
+
+        /* this covers depth=3 or higher. */
+        [data-depth] { margin-left: 45px; }
+
+        [data-depth="0"] { margin-left: 0px; }
+        [data-depth="1"] { margin-left: 15px; }
+        [data-depth="2"] { margin-left: 30px; }
+
+        iframe {
+          flex-grow: 1;
+          max-width: 734px;
+          margin: 20px;
+          box-shadow: rgba(0, 0, 0, 0.15) 0 3px 10px;
+          padding: 20px 60px;
+          border: 1px solid #ccc;
+          border-radius: 5px;
+          background: #fff;
+        }
+
+        a, a:visited {
+          display: block;
+          color: #44f;
+          text-decoration: none;
+        }
+        a:hover {
+          background: #eef;
+        }
+        a.selected {
+          background: #44f;
+          color: #fff;
+        }
+        
+
+      </style>
+    </head>
+    <body>
+      <div id="tree">%s</div>
+      <iframe name="iframe" src=""></iframe>
+      <iframe id="source" style="display: none" src=""></iframe>
+      <script>
+
+        var sourceIframe = document.getElementById("source");
+        var links = document.querySelectorAll("#tree a");
+        var currentIndex = -1;
+
+        links.forEach(function(link, index) {
+          link.onclick = function() {
+            links[currentIndex].classList.remove("selected");
+            currentIndex = index;
+            link.classList.add("selected");
+
+            var originalUrl = link.getAttribute("data-original-url");
+            if (originalUrl) {
+              sourceIframe.src = originalUrl.startsWith("/") ? "file://" + originalUrl : originalUrl;
+              sourceIframe.style.display = "block";
+            } else {
+              sourceIframe.style.display = "none";
+            }
+          }
+        });
+
+
+        function next() {
+          if (links[currentIndex]) {
+            links[currentIndex].classList.remove("selected");
+          }
+          currentIndex = (currentIndex + 1) %% links.length;
+          links[currentIndex].classList.add("selected");
+          links[currentIndex].click();
+        }
+        function prev() {
+          if (links[currentIndex]) {
+            links[currentIndex].classList.remove("selected");
+          }
+          currentIndex = (currentIndex - 1 + links.length) %% links.length;
+          links[currentIndex].classList.add("selected");
+          links[currentIndex].click();
+        }
+
+        document.onkeydown = function(event) {
+          if (event.keyCode == 38) {
+            prev();
+            event.preventDefault();
+          } else if (event.keyCode == 40) {
+            next();
+            event.preventDefault();
+          }
+        };
+        next();
+
+      </script>
+    </body>
+  </html>
+  """ % ("").join(self.html_pieces)
+
+      write_file(self.card_preview_path % self.task_name, html)
+      if open_browser:
+        webbrowser.open_new_tab("file://" + self.card_preview_path % self.task_name)
+

--- a/guru/find_and_replace.py
+++ b/guru/find_and_replace.py
@@ -7,19 +7,22 @@ from bs4 import BeautifulSoup
 
 def replace_text_in_text(text, term, replacement, case_sensitive=False):
   # replacement = "[start]Customer[end]".capitalize()
+  original_text = text
   lowercased_term = term.lower()
   lowercased_replacement = replacement.lower().replace("[guru_sdk_highlight_start]", "[GURU_SDK_HIGHLIGHT_START]").replace("[guru_sdk_highlight_end]", "[GURU_SDK_HIGHLIGHT_END]")
   uppercased_term = term.upper()
   uppercased_replacement = replacement.upper()
   capitalized_term = term.capitalize()
-  if "[GURU_SDK_HIGHLIGHT_START]" in replacement:
+  if "[GURU_SDK_HIGHLIGHT_START]" in replacement and "[GURU_SDK_HIGHLIGHT_END]" in replacement:
+    replacement = replacement.replace("[GURU_SDK_HIGHLIGHT_END]", "")
     replacement = replacement.replace("[GURU_SDK_HIGHLIGHT_START]", "")
-    capitalized_replacement = "[GURU_SDK_HIGHLIGHT_START]" + replacement.capitalize()
+    capitalized_replacement = "[GURU_SDK_HIGHLIGHT_START]" + replacement.capitalize() + "[GURU_SDK_HIGHLIGHT_END]"
   elif "[GURU_SDK_HIGHLIGHT_END]" in replacement:
     replacement = replacement.replace("[GURU_SDK_HIGHLIGHT_END]", "")
     capitalized_replacement = "[GURU_SDK_HIGHLIGHT_END]" + replacement.capitalize()
-
-
+  elif "[GURU_SDK_HIGHLIGHT_START]" in replacement:
+    replacement = replacement.replace("[GURU_SDK_HIGHLIGHT_START]", "")
+    capitalized_replacement = "[GURU_SDK_HIGHLIGHT_START]" + replacement.capitalize()
   else:
     capitalized_replacement = replacement.capitalize()
   if case_sensitive:
@@ -56,8 +59,8 @@ def replace_text_in_card(card, term, replacement, replace_title=True, highlight=
     if highlight:
       card = replace_text_in_html(card, term, "[GURU_SDK_HIGHLIGHT_START]%s[GURU_SDK_HIGHLIGHT_END]" % replacement)
       # do string replacements on the [start] and [end] tokens.
-      # card = replace_text_in_text(str(card), "[GURU_SDK_HIGHLIGHT_START]", '<span class="sdk-highlight">', case_sensitive=True)
-      # card = replace_text_in_text(str(card), "[GURU_SDK_HIGHLIGHT_END]", "</span>", case_sensitive=True)
+      card = replace_text_in_text(str(card), "[GURU_SDK_HIGHLIGHT_START]", '<span class="sdk-highlight">', case_sensitive=True)
+      card = replace_text_in_text(str(card), "[GURU_SDK_HIGHLIGHT_END]", "</span>", case_sensitive=True)
     else:
       card = replace_text_in_html(card, term, replacement)
     return card

--- a/guru/find_and_replace.py
+++ b/guru/find_and_replace.py
@@ -3,7 +3,7 @@ import webbrowser
 from guru.util import write_file, load_html
 from guru.data_objects import Card
 
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from bs4 import BeautifulSoup
 
 # for markdown_div in card.doc.select("[data-ghq-card-content-markdown-content]"):
@@ -56,6 +56,15 @@ def replace_text_in_text(text, term, replacement, term_case_sensitive=False, rep
   
   return text
 
+def replace_in_markdown_block(doc, term, replacement, replacement_case_sensitive=False):
+  for markdown_div in doc.select("[data-ghq-card-content-markdown-content]"):
+    md = unquote(markdown_div.attrs.get("data-ghq-card-content-markdown-content"))
+    new_md = replace_text_in_text(md, term, replacement, replacement_case_sensitive=replacement_case_sensitive)
+    markdown_div.attrs["data-ghq-card-content-markdown-content"] = quote(new_md)
+
+
+
+
 def replace_text_in_html(html, term, replacement, term_case_sensitive=False, replacement_case_sensitive=False):
   doc = html if isinstance(html, BeautifulSoup) else BeautifulSoup(html, "html.parser")
   pattern = re.compile(r'%s' % term, re.IGNORECASE)
@@ -64,6 +73,7 @@ def replace_text_in_html(html, term, replacement, term_case_sensitive=False, rep
     text_node.replace_with(replace_text_in_text(
       text_node, term, replacement, replacement_case_sensitive=replacement_case_sensitive
     ))
+  replace_in_markdown_block(doc, term, replacement)
   return str(doc)
 
 def add_highlight(card, term, replacement, highlight="replacement", case_sensitive=False):

--- a/guru/find_and_replace.py
+++ b/guru/find_and_replace.py
@@ -6,17 +6,24 @@ from guru.data_objects import Card
 from urllib.parse import quote, unquote
 from bs4 import BeautifulSoup
 
-# for markdown_div in card.doc.select("[data-ghq-card-content-markdown-content]"):
-#       md = unquote(markdown_div.attrs.get("data-ghq-card-content-markdown-content"))
-#       html = markdown.markdown(md)
-#       doc = BeautifulSoup(html, "html.parser")
-
 def get_term_count(text, term):
   doc = BeautifulSoup(text, "html.parser")
   lowered_doc = doc.text.lower()
   return lowered_doc.count(term.lower())
 
 def replace_text_in_text(text, term, replacement, term_case_sensitive=False, replacement_case_sensitive=False):
+  """
+  Replaces term in text (string). Accounts for lowercase, uppercase, capitalized, and title-cased
+
+  Arguments:
+    text (str): text that contains the term we want to replace,
+    term (str): term we want to replace,
+    replacement (str): replacement term,
+    term_case_sensitive (bool): boolean for searching for the specific term or case-insensitive (defaults to false ),
+    replacement_case_sensitive (bool): boolean for replacement term case-sensitivity (defaults to false)
+
+  Returns: text (str) with replacement
+  """
   # replacement = "[start]Customer[end]".capitalize()
   lowercased_term = term.lower()
   lowercased_replacement = replacement.lower().replace("[guru_sdk_highlight_start]", "[GURU_SDK_HIGHLIGHT_START]").replace("[guru_sdk_highlight_end]", "[GURU_SDK_HIGHLIGHT_END]")
@@ -57,13 +64,19 @@ def replace_text_in_text(text, term, replacement, term_case_sensitive=False, rep
   return text
 
 def replace_in_markdown_block(doc, term, replacement, replacement_case_sensitive=False):
+  """
+  Replace text in markdown blocks (markdown content in data-ghq-card-content-markdown-content attribute)
+
+  Arguments:
+    doc (BeautifulSoup): html document object
+    term (str): term to replace
+    replacement (str): replacement term
+    replacement_case_sensitive (bool): boolean for replacement term case-sensitivity (defaults to false)
+  """
   for markdown_div in doc.select("[data-ghq-card-content-markdown-content]"):
     md = unquote(markdown_div.attrs.get("data-ghq-card-content-markdown-content"))
     new_md = replace_text_in_text(md, term, replacement, replacement_case_sensitive=replacement_case_sensitive)
     markdown_div.attrs["data-ghq-card-content-markdown-content"] = quote(new_md)
-
-
-
 
 def replace_text_in_html(html, term, replacement, term_case_sensitive=False, replacement_case_sensitive=False):
   doc = html if isinstance(html, BeautifulSoup) else BeautifulSoup(html, "html.parser")

--- a/tests/test_find_and_replace.py
+++ b/tests/test_find_and_replace.py
@@ -2,6 +2,7 @@ import json
 import unittest
 import responses
 
+
 from tests.util import use_guru, get_calls
 
 import guru
@@ -154,37 +155,45 @@ class TestFindAndReplace(unittest.TestCase):
     })
     responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/2222/extended", json={
       "preferredPhrase": "Testing 1, 2, 3",
-      "content": """#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph.\n\nHere is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph."""
+      "content": """#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph.\n\nHere is a test paragraph. Here is a test paragraph."""
     })
     card = g.get_card("1111")
     markdown_card = g.get_card("2222")
 
     expected_html = """<p>PURPLE</p>"""
     expected_html_highlight = """<p><span class="sdk-replacement-highlight">PURPLE</span></p>"""
-    expected_markdown = """<p><Purple</p>"""
+    expected_title = "Purpleing 1, 2, 3"
+    expected_markdown = """#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a purple paragraph. Here is a purple paragraph. Here is a purple paragraph. Here is a purple paragraph. Here is a purple paragraph.\n\nHere is a purple paragraph. Here is a purple paragraph."""
     expected_markdown_highlight = """<p><span class="sdk-replacement-highlight">Purple</span></p>"""
     
     test_result = guru.replace_text_in_card(card, term, replacement)
     markdown_test_result = guru.replace_text_in_card(markdown_card, term, replacement)
-    test_highlight_result = guru.replace_text_in_card(card, term, replacement, replacement_highlight=True, orig_highlight=True)
-    markdown_highlight_test_result = guru.replace_text_in_card(markdown_card, term, replacement, replacement_highlight=True, orig_highlight=True)
+    test_orig_highlight_result = guru.replace_text_in_card(card, term, term, orig_highlight=True)
+    test_replacement_highlight_result = guru.replace_text_in_card(card, replacement, replacement, replacement_highlight=True)
+    markdown_highlight_test_result = guru.replace_text_in_card(markdown_card, replacement, replacement, replacement_highlight=True, orig_highlight=True)
     ## replace title and content
+    guru.replace_text_in_card(card, term, replacement, replace_title=True)
 
     ## content is html
     print("RESULT 1: ", test_result)
     self.assertEqual(test_result, expected_html)
     ## content is markdown
-    # print("RESULT 2: ", markdown_test_result)
-    # self.assertEqual(markdown_test_result, expected_markdown)
+    print("RESULT 2: ", markdown_test_result)
+    self.assertEqual(markdown_test_result, expected_markdown)
     ## highlighted content: is html
-    print("RESULT 3: ", test_highlight_result)
-    self.assertEqual(test_highlight_result, expected_html_highlight)
+    print("RESULT 3: ", test_replacement_highlight_result)
+    self.assertEqual(test_replacement_highlight_result, expected_html_highlight)
     ## highlighted content: is markdown
     print("RESULT 4: ", markdown_highlight_test_result)
     # self.assertEqual(markdown_highlight_test_result, expected_markdown_highlight)
+    ## replace title
+    print("RESULT 5: ", card.title)
+    self.assertEqual(card.title, expected_title)
     
   
+## Write test for get_term_count
 
+## Write test for markdown ( parse and replace with urllib.parse.quote)
 
 
   

--- a/tests/test_find_and_replace.py
+++ b/tests/test_find_and_replace.py
@@ -21,15 +21,16 @@ class TestFindAndReplace(unittest.TestCase):
 
     # md_content="""#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a test paragraph. Here is a test paragraph."""
 
+    test_result = guru.replace_text_in_text(content, term, replacement)
+    term_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, term_case_sensitive=True)
+    replacement_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, replacement_case_sensitive=True)
+    test_titlecase_result = guru.replace_text_in_text(titlecased_content, term_for_testing_titlecase, replacement)
+    
     expected = "PURPLE, Purple"
     expected_term_case_sensitive = "TEST, Purple"
     expected_replacement_case_sensitive = "Purple, Purple"
     expected_titlecase = "Purple"
     
-    test_result = guru.replace_text_in_text(content, term, replacement)
-    term_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, term_case_sensitive=True)
-    replacement_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, replacement_case_sensitive=True)
-    test_titlecase_result = guru.replace_text_in_text(titlecased_content, term_for_testing_titlecase, replacement)
     ## replacement is not case-sensitive
     print("RESULT 1: ", test_result)
     self.assertEqual(test_result, expected)
@@ -53,13 +54,14 @@ class TestFindAndReplace(unittest.TestCase):
     replacement = "[GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
     content= "TEST, Test"
 
+    test_result = guru.replace_text_in_text(content, term, replacement)
+    term_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, term_case_sensitive=True)
+    replacement_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, replacement_case_sensitive=True)
+    
     expected = "[GURU_SDK_HIGHLIGHT_START]TEST[GURU_SDK_HIGHLIGHT_END], [GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
     expected_term_case_sensitive = "TEST, [GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
     expected_replacement_case_sensitive = "[GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END], [GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
     
-    test_result = guru.replace_text_in_text(content, term, replacement)
-    term_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, term_case_sensitive=True)
-    replacement_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, replacement_case_sensitive=True)
     ## replacement is not case-sensitive
     print("RESULT 1: ", test_result)
     self.assertEqual(test_result, expected)
@@ -86,12 +88,13 @@ class TestFindAndReplace(unittest.TestCase):
     card_content = g.get_card("1111").doc
 
 
-    expected_html = """<p>PURPLE</p>"""
-    expected_html_replacement_case_sensitive = """<p>Purple</p>"""
-    
     test_result = guru.replace_text_in_html(html_content, term, replacement)
     card_content_test_result = guru.replace_text_in_html(card_content, term, replacement)
     replacement_case_sensitive_test_result = guru.replace_text_in_html(html_content, term, replacement, replacement_case_sensitive=True)
+    
+    expected_html = """<p>PURPLE</p>"""
+    expected_html_replacement_case_sensitive = """<p>Purple</p>"""
+    
     ## replacement term is not case-sensitive
     print("RESULT 1: ", test_result)
     self.assertEqual(test_result, expected_html)
@@ -118,15 +121,15 @@ class TestFindAndReplace(unittest.TestCase):
     term_card = g.get_card("1111")
     replacement_card = g.get_card("2222")
 
-    expected_term = """<p><span class="sdk-orig-highlight">Test</span></p>"""
-    expected_replacement = """<p><span class="sdk-replacement-highlight">Purple</span></p>"""
-    
     # card.content
     test_term_result = guru.add_highlight(term_card.content, term, term, highlight="original")
     test_replacement_result = guru.add_highlight(replacement_card.content, replacement, replacement, highlight="replacement")
     # card instance
     test_term_card_result = guru.add_highlight(term_card, term, term, highlight="original")
     test_replacement_card_result = guru.add_highlight(replacement_card, replacement, replacement, highlight="replacement")
+    
+    expected_term = """<p><span class="sdk-orig-highlight">Test</span></p>"""
+    expected_replacement = """<p><span class="sdk-replacement-highlight">Purple</span></p>"""
     
     ## term highlight
     print("RESULT 1: ", test_term_result)
@@ -160,17 +163,18 @@ class TestFindAndReplace(unittest.TestCase):
     card = g.get_card("1111")
     markdown_card = g.get_card("2222")
 
+    test_result = guru.replace_text_in_card(card, term, replacement)
+    markdown_test_result = guru.replace_text_in_card(markdown_card, term, replacement)
+    test_orig_highlight_result = guru.replace_text_in_card(card, term, term, orig_highlight=True)
+    test_replacement_highlight_result = guru.replace_text_in_card(card, replacement, replacement, replacement_highlight=True)
+    markdown_highlight_test_result = guru.replace_text_in_card(markdown_card, replacement, replacement, replacement_highlight=True, orig_highlight=True)
+
     expected_html = """<p>PURPLE</p>"""
     expected_html_highlight = """<p><span class="sdk-replacement-highlight">PURPLE</span></p>"""
     expected_title = "Purpleing 1, 2, 3"
     expected_markdown = """#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a purple paragraph. Here is a purple paragraph. Here is a purple paragraph. Here is a purple paragraph. Here is a purple paragraph.\n\nHere is a purple paragraph. Here is a purple paragraph."""
     expected_markdown_highlight = """<p><span class="sdk-replacement-highlight">Purple</span></p>"""
     
-    test_result = guru.replace_text_in_card(card, term, replacement)
-    markdown_test_result = guru.replace_text_in_card(markdown_card, term, replacement)
-    test_orig_highlight_result = guru.replace_text_in_card(card, term, term, orig_highlight=True)
-    test_replacement_highlight_result = guru.replace_text_in_card(card, replacement, replacement, replacement_highlight=True)
-    markdown_highlight_test_result = guru.replace_text_in_card(markdown_card, replacement, replacement, replacement_highlight=True, orig_highlight=True)
     ## replace title and content
     guru.replace_text_in_card(card, term, replacement, replace_title=True)
 

--- a/tests/test_find_and_replace.py
+++ b/tests/test_find_and_replace.py
@@ -1,0 +1,190 @@
+import json
+import unittest
+import responses
+
+from tests.util import use_guru, get_calls
+
+import guru
+
+
+class TestFindAndReplace(unittest.TestCase):
+
+
+  @use_guru()
+  def test_replace_term_in_text(self,g):
+    term = "Test"
+    term_for_testing_titlecase = "Test case"
+    replacement = "Purple"
+    content = "TEST, Test"
+    titlecased_content = "Test Case"
+
+    # md_content="""#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a test paragraph. Here is a test paragraph."""
+
+    expected = "PURPLE, Purple"
+    expected_term_case_sensitive = "TEST, Purple"
+    expected_replacement_case_sensitive = "Purple, Purple"
+    expected_titlecase = "Purple"
+    
+    test_result = guru.replace_text_in_text(content, term, replacement)
+    term_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, term_case_sensitive=True)
+    replacement_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, replacement_case_sensitive=True)
+    test_titlecase_result = guru.replace_text_in_text(titlecased_content, term_for_testing_titlecase, replacement)
+    ## replacement is not case-sensitive
+    print("RESULT 1: ", test_result)
+    self.assertEqual(test_result, expected)
+    ## term is case-sensitive
+    print("RESULT 2: ", term_case_sensitive_test_result)
+    self.assertEqual(term_case_sensitive_test_result, expected_term_case_sensitive)
+    ## replacement is case-sensitive
+    print("RESULT 3: ", replacement_case_sensitive_test_result)
+    self.assertEqual(replacement_case_sensitive_test_result, expected_replacement_case_sensitive)
+    ## uncommon content, so need to replace will only find 
+    print("RESULT 4: ", guru.replace_text_in_text("TesT test", term, replacement))
+    self.assertEqual(guru.replace_text_in_text("TesT test", "TesT", "PurplE", term_case_sensitive=True), "PurplE test")
+    ## titlecase
+    print("RESULT 5: ", test_titlecase_result)
+    self.assertEqual(test_titlecase_result, expected_titlecase)
+
+
+  @use_guru()
+  def test_replace_term_in_text_with_highlight_span(self,g):
+    term = "Test"
+    replacement = "[GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
+    content= "TEST, Test"
+
+    expected = "[GURU_SDK_HIGHLIGHT_START]TEST[GURU_SDK_HIGHLIGHT_END], [GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
+    expected_term_case_sensitive = "TEST, [GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
+    expected_replacement_case_sensitive = "[GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END], [GURU_SDK_HIGHLIGHT_START]Test[GURU_SDK_HIGHLIGHT_END]"
+    
+    test_result = guru.replace_text_in_text(content, term, replacement)
+    term_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, term_case_sensitive=True)
+    replacement_case_sensitive_test_result = guru.replace_text_in_text(content, term, replacement, replacement_case_sensitive=True)
+    ## replacement is not case-sensitive
+    print("RESULT 1: ", test_result)
+    self.assertEqual(test_result, expected)
+    ## term is case-sensitive
+    print("RESULT 2: ", term_case_sensitive_test_result)
+    self.assertNotEqual(term_case_sensitive_test_result, expected_term_case_sensitive)
+    ## replacement is case-sensitive
+    print("RESULT 3: ", replacement_case_sensitive_test_result)
+    self.assertNotEqual(replacement_case_sensitive_test_result, expected_replacement_case_sensitive)
+
+  
+  @use_guru()
+  @responses.activate
+  def test_replace_term_in_html(self,g):
+    term = "Test"
+    replacement = "Purple"
+    html_content = """<p>TEST</p>"""
+    md_content="""#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph.\n\nHere is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph."""
+    
+    # register the response for the API call we'll make.
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1111/extended", json={
+      "content": html_content
+    })
+    card_content = g.get_card("1111").doc
+
+
+    expected_html = """<p>PURPLE</p>"""
+    expected_html_replacement_case_sensitive = """<p>Purple</p>"""
+    
+    test_result = guru.replace_text_in_html(html_content, term, replacement)
+    card_content_test_result = guru.replace_text_in_html(card_content, term, replacement)
+    replacement_case_sensitive_test_result = guru.replace_text_in_html(html_content, term, replacement, replacement_case_sensitive=True)
+    ## replacement term is not case-sensitive
+    print("RESULT 1: ", test_result)
+    self.assertEqual(test_result, expected_html)
+    ## replacement term is case-sensitive
+    print("RESULT 2: ", replacement_case_sensitive_test_result)
+    self.assertEqual(replacement_case_sensitive_test_result, expected_html_replacement_case_sensitive)
+    ## html is from a card (BeautifulSoup instance)
+    print("RESULT 3: ", card_content_test_result)
+    self.assertEqual(card_content_test_result, expected_html)
+  
+  @use_guru()
+  @responses.activate
+  def test_add_highlight(self, g):
+    term = "Test"
+    replacement = "Purple"
+  
+    # register the response for the API call we'll make.
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1111/extended", json={
+      "content": """<p>Test</p>"""
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/2222/extended", json={
+      "content": """<p>Purple</p>"""
+    })
+    term_card = g.get_card("1111")
+    replacement_card = g.get_card("2222")
+
+    expected_term = """<p><span class="sdk-orig-highlight">Test</span></p>"""
+    expected_replacement = """<p><span class="sdk-replacement-highlight">Purple</span></p>"""
+    
+    # card.content
+    test_term_result = guru.add_highlight(term_card.content, term, term, highlight="original")
+    test_replacement_result = guru.add_highlight(replacement_card.content, replacement, replacement, highlight="replacement")
+    # card instance
+    test_term_card_result = guru.add_highlight(term_card, term, term, highlight="original")
+    test_replacement_card_result = guru.add_highlight(replacement_card, replacement, replacement, highlight="replacement")
+    
+    ## term highlight
+    print("RESULT 1: ", test_term_result)
+    self.assertEqual(test_term_result, expected_term)
+    ## replacement highlight
+    print("RESULT 2: ", test_replacement_result)
+    self.assertEqual(test_replacement_result, expected_replacement)
+    
+    ## term highlight (card instance)
+    print("RESULT 3: ", test_term_card_result)
+    self.assertEqual(test_term_card_result, expected_term)
+    ## replacement highlight (card instance)
+    print("RESULT 4: ", test_replacement_card_result)
+    self.assertEqual(test_replacement_card_result, expected_replacement)
+    
+  @use_guru()
+  @responses.activate
+  def test_replace_term_in_card(self,g):
+    term = "Test"
+    replacement = "Purple"
+
+    # register the response for the API call we'll make.
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1111/extended", json={
+      "preferredPhrase": "Testing 1, 2, 3",
+      "content": """<p>TEST</p>"""
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/2222/extended", json={
+      "preferredPhrase": "Testing 1, 2, 3",
+      "content": """#Header 1\n##Header2\n###Header3\n\n\n\n# Header 1\n## Header 2\n### Header 3\n\nHere is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph.\n\nHere is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph. Here is a test paragraph."""
+    })
+    card = g.get_card("1111")
+    markdown_card = g.get_card("2222")
+
+    expected_html = """<p>PURPLE</p>"""
+    expected_html_highlight = """<p><span class="sdk-replacement-highlight">PURPLE</span></p>"""
+    expected_markdown = """<p><Purple</p>"""
+    expected_markdown_highlight = """<p><span class="sdk-replacement-highlight">Purple</span></p>"""
+    
+    test_result = guru.replace_text_in_card(card, term, replacement)
+    markdown_test_result = guru.replace_text_in_card(markdown_card, term, replacement)
+    test_highlight_result = guru.replace_text_in_card(card, term, replacement, replacement_highlight=True, orig_highlight=True)
+    markdown_highlight_test_result = guru.replace_text_in_card(markdown_card, term, replacement, replacement_highlight=True, orig_highlight=True)
+    ## replace title and content
+
+    ## content is html
+    print("RESULT 1: ", test_result)
+    self.assertEqual(test_result, expected_html)
+    ## content is markdown
+    # print("RESULT 2: ", markdown_test_result)
+    # self.assertEqual(markdown_test_result, expected_markdown)
+    ## highlighted content: is html
+    print("RESULT 3: ", test_highlight_result)
+    self.assertEqual(test_highlight_result, expected_html_highlight)
+    ## highlighted content: is markdown
+    print("RESULT 4: ", markdown_highlight_test_result)
+    # self.assertEqual(markdown_highlight_test_result, expected_markdown_highlight)
+    
+  
+
+
+
+  


### PR DESCRIPTION
CH ticket: https://app.clubhouse.io/guru/story/53593/find-and-replace-preview-utility-for-the-sdk
## Overview

This PR adds an in-browser preview for find and replace.
The tool can replace content in html, text strings, and markdown attributes. 
The code is meant to be modular and flexible, so you could use parts of this functionality or the whole thing, but will allow you control over some elements of the find and replace task.


Tests have been added to cover some cases of content that we'd want to consider, but I may add more cases.
Also in the process of adding more doc strings to the associated functions and methods.