### PR TITLE
bug/johnchappelle/ch56751/fix-file-uploads-in-the-sdk

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -4,6 +4,7 @@ import re
 import sys
 import time
 import requests
+import mimetypes
 
 from requests.auth import HTTPBasicAuth
 
@@ -1214,9 +1215,11 @@ class Guru:
 
     # read the file and upload it to filestack.
     with open(filename, "rb") as file_in:
-      url = "https://www.filepicker.io/api/store/S3?key=%s&filename=%s&path=%s&signature=%s&policy=%s" % (
+      file_mimetype, file_encoding = mimetypes.guess_type(filename)
+      url = "https://www.filepicker.io/api/store/S3?key=%s&filename=%s&mimetype=%s&path=%s&signature=%s&policy=%s" % (
         upload_key.get("apiKey"),
         os.path.basename(filename),
+        file_mimetype,
         upload_key.get("path"),
         upload_key.get("signature"),
         upload_key.get("policy")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -517,32 +517,12 @@ class TestEndToEnd(unittest.TestCase):
   def test_mimetype_return(self, g):
     # write a local text file.
     filename = "/tmp/upload.txt"
-    
     guru.write_file(filename, "sample file")
     file_mimetype, file_encoding = mimetypes.guess_type(filename)
 
-    upload_key_url = "https://api.getguru.com/api/v1/attachments/policy"
-    upload_key = requests.get(upload_key_url, auth=(SDK_E2E_USER, SDK_E2E_TOKEN)).json()
-
-    # read the file and upload it to filestack.
-    with open(filename, "rb") as file_in:
-      upload_url = "https://www.filepicker.io/api/store/S3?key=%s&filename=%s&mimetype=%s&path=%s&signature=%s&policy=%s" % (
-        upload_key.get("apiKey"),
-        os.path.basename(filename),
-        file_mimetype,
-        upload_key.get("path"),
-        upload_key.get("signature"),
-        upload_key.get("policy")
-      )
-      files = {
-        "fileUpload": (filename, file_in)
-      }
-      response = requests.post(upload_url, files=files, auth=(SDK_E2E_USER, SDK_E2E_TOKEN))
-      fs_data = response.json()
-
-      # assert that the mimetype we pass in the query string is what is returned as `type` in the response
-      self.assertEqual(fs_data.get("type"), file_mimetype)
-  
+    # assert that the mimetype we get from the filestack response matches the mimetype we get from the mimetype module
+    fs_data = g.upload_to_filestack(filename)
+    self.assertEqual(fs_data.get("type"), file_mimetype)
 
 # these are the methods that aren't tested yet:
 # add_users_to_group

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,6 +1,7 @@
 
 import unittest
 import requests
+import mimetypes
 
 from tests.util import use_guru
 
@@ -511,6 +512,37 @@ class TestEndToEnd(unittest.TestCase):
     # download the file to check that it worked.
     response = requests.get(guru_url, auth=(SDK_E2E_USER, SDK_E2E_TOKEN))
     self.assertEqual(response.content.decode("utf-8"), "sample file")
+  
+  @use_guru(SDK_E2E_USER, SDK_E2E_TOKEN)
+  def test_mimetype_return(self, g):
+    # write a local text file.
+    filename = "/tmp/upload.txt"
+    
+    guru.write_file(filename, "sample file")
+    file_mimetype, file_encoding = mimetypes.guess_type(filename)
+
+    upload_key_url = "https://api.getguru.com/api/v1/attachments/policy"
+    upload_key = requests.get(upload_key_url, auth=(SDK_E2E_USER, SDK_E2E_TOKEN)).json()
+
+    # read the file and upload it to filestack.
+    with open(filename, "rb") as file_in:
+      upload_url = "https://www.filepicker.io/api/store/S3?key=%s&filename=%s&mimetype=%s&path=%s&signature=%s&policy=%s" % (
+        upload_key.get("apiKey"),
+        os.path.basename(filename),
+        file_mimetype,
+        upload_key.get("path"),
+        upload_key.get("signature"),
+        upload_key.get("policy")
+      )
+      files = {
+        "fileUpload": (filename, file_in)
+      }
+      response = requests.post(upload_url, files=files, auth=(SDK_E2E_USER, SDK_E2E_TOKEN))
+      fs_data = response.json()
+
+      # assert that the mimetype we pass in the query string is what is returned as `type` in the response
+      self.assertEqual(fs_data.get("type"), file_mimetype)
+  
 
 # these are the methods that aren't tested yet:
 # add_users_to_group


### PR DESCRIPTION
CH ticket: https://app.clubhouse.io/guru/story/56751/fix-file-uploads-in-the-sdk

## Overview

When uploading a file to Filestack, using the SDK, we were getting a mimetype of `multipart/form-data` returned. When we pass this data to the `attachments` endpoint, this would cause the file to be downloaded, instead of opening in the browser, when accessed from a card in Guru. 

In order for it to return the correct mimetype ( i.e. `text/plain`), we need to pass the file's mimetype in the query string of the filestack upload url. We can get this mimetype by using the `mimetypes` Python module. The `mimetypes.guess_type()` method return a tuple of the type and the file encoding.

I tested this by saving the response JSON from the Filepicker.io POST call, running `test_upload_file` in `test_e2e.py` and validating that the type is what it should be ( for `.txt` file, `text/plain`).
```{
  "container": "fs.getguru.com",
  "url": "https://cdn.filepicker.io/api/file/mLQp0sTXTpaY7zWC8UXT",
  "filename": "upload.txt",
  "key": "658da94b-2a07-4634-a009-76c908cbefce/lMUdV3cLQDyWi05wPrFM_upload.txt",
  "type": "text/plain",
  "size": 11
}
```





 