### PR TITLE
update reference url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ pip install git+https://github.com/guruhq/py-sdk.git
 
 Check the scripts in the `examples/` folder to see examples of how to use the Guru SDK.
 
-Also check out the wiki for a [comprehensive reference](https://github.com/guruhq/py-sdk/wiki/The-Guru-Object).
+Also check out the wiki for a [comprehensive reference](https://github.com/guruhq/py-sdk/wiki).


### PR DESCRIPTION
CH Ticket: https://app.clubhouse.io/guru/story/60348/update-sdk-wiki-url-in-readme-file

This updates the reference url in the README from [https://github.com/guruhq/py-sdk/wiki/The-Guru-Object](https://github.com/guruhq/py-sdk/wiki/The-Guru-Object) to [https://github.com/guruhq/py-sdk/wiki](https://github.com/guruhq/py-sdk/wiki)