### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,13 @@ if __name__ == "__main__":
     version="1.0.0",
     url="https://github.com/guruhq/py-sdk",
     packages=["guru"],
+    install_requires=[
+        "beautifulsoup4",
+        "markdown",
+        "python-dateutil",
+        "pytz",
+        "PyYAML",
+        "requests",
+    ],
     python_requires=">=2.7"
   )


### PR DESCRIPTION
# Purpose
Ensure `py-sdk` is pip-installable.  Pip uses the dependencies declared in `setup.py`.

# Implementation
Update the `setup.py` to include the list of dependencies needed for installing `py-sdk`.  We might want to add some loose version constraints here as well, but declaring the dependencies at all is probably the first step.