### PR TITLE
Feature/johnchappelle/ch60389/add light users to the sdk

### DIFF
--- a/examples/user_management.py
+++ b/examples/user_management.py
@@ -8,6 +8,18 @@ g = guru.Guru()
 # g.invite_user("rmiller+test2@getguru.com", "group name")
 # g.invite_user("rmiller+test3@getguru.com", "group name", "other group", "group 3")
 
+# invite a core user and add to groups
+# g.invite_core_user("jchappelle+coreuser@getguru.com", "group name", "other group", "group 3")
+
+# # invite a light user
+# g.invite_light_user("jchappelle+lightuser@getguru.com")
+
+# # upgrade a light user to core
+# g.upgrade_light_user("jchappelle+lightuser@getguru.com")
+
+# # downgrade a core user to light
+# g.downgrade_core_user("jchappelle+coreuser@getguru.com")
+
 # # create a new group
 # g.make_group("New Group")
 
@@ -19,5 +31,7 @@ g = guru.Guru()
 # g.remove_user_from_team("rmiller+test1@getguru.com")
 # g.remove_user_from_team("rmiller+test2@getguru.com")
 # g.remove_user_from_team("rmiller+test3@getguru.com")
+# g.remove_user_from_team("jchappelle+lightuser@getguru.com")
+# g.remove_user_from_team("jchappelle+coreuser@getguru.com")
 
 # g.delete_group("New Group")

--- a/guru/core.py
+++ b/guru/core.py
@@ -789,7 +789,7 @@ class Guru:
       self.__log(make_red("could not find user:", email))
       return
 
-    if user.access_type != "READ_ONLY" and user.billing_type != "FREE":
+    if not user.is_light:
       self.__log(make_red("user is not a light user:", email))
       return
   
@@ -797,7 +797,7 @@ class Guru:
     url = "%s/members/%s/upgrade" % (self.base_url, email)
     response = self.__post(url, data)
 
-    return response.json(), response.status_code 
+    return status_to_bool(response.status_code)
   
   def downgrade_core_user(self, email):
     """
@@ -824,7 +824,7 @@ class Guru:
       self.__log(make_red("could not find user:", email))
       return
 
-    if user.access_type != "CORE" and user.billing_type != "CORE":
+    if not user.is_core:
       self.__log(make_red("user is not a core user:", email))
       return
   
@@ -832,7 +832,7 @@ class Guru:
     url = "%s/members/%s/downgrade" % (self.base_url, email)
     response = self.__post(url, data)
 
-    return response.json(), response.status_code 
+    return status_to_bool(response.status_code)
   
   def add_users_to_group(self, emails, group):
     """
@@ -932,7 +932,7 @@ class Guru:
       self.__log(make_red("could not find user:", email))
       return
 
-    if user.access_type == "READ_ONLY" and user.billing_type == "FREE":
+    if user.is_light:
       self.__log(make_red("user is a light user, and cannot belong to groups:", email))
       return
 

--- a/guru/core.py
+++ b/guru/core.py
@@ -642,6 +642,46 @@ class Guru:
     users = [User(u) for u in users]
     return users
 
+  def __invite_user(self, email, is_light_user=False, *groups):
+    """
+    Internal
+
+    Args:
+      email (str): The email address of the user to add to the team.
+      *groups (str): Any number of groups to add the user to.
+    
+    Returns:
+      response (str): parsed JSON response.
+      status (int): response status code
+    """
+    groups = list(groups)
+
+    if not is_email(email):
+      raise ValueError("invalid email '%s'" % email)
+    
+    if groups:
+      self.__log("invite user", make_blue(email), "and then add them to:", make_blue(groups))
+    else:
+      self.__log("invite user", make_blue(email))
+    
+    if is_light_user:
+      data = { "emails": email, "teamMemberType": "LIGHT" }
+    else:
+      data = { "emails": email, "teamMemberType": "CORE" }
+    url = "%s/members/invite" % self.base_url
+    response = self.__post(url, data)
+
+    # if there are remaining groups, call add_user_to_groups() for that.
+    if groups:
+      # todo: when we call this, it'll make a GET call to load this user to see if they're
+      #       already in any of the groups we're trying to add them to -- in this case, since
+      #       we _just_ invited them, we know they won't be. it'd be great to be able to skip
+      #       that GET call in this situation.
+      self.add_user_to_groups(email, *groups)
+    
+    # todo: return a dict that maps email -> bool indicating if the user was invited successfully.
+    return response.json(), response.status_code
+  
   def invite_user(self, email, *groups):
     """
     Adds a user to the team and adds them to the groups provided.
@@ -663,32 +703,100 @@ class Guru:
       *groups (str): Any number of groups to add the user to.
     
     Returns:
+      response (str): parsed JSON response.
+      status (int): response status code
+    """
+
+    response, status = self.__invite_user(email, *groups)
+
+    return response, status
+
+  def invite_light_user(self, email):
+    """
+    Adds a user to the team as a light user.
+    Light users can't belong to groups, so they automatically go into the All Members group.
+    The user may receive an email because of this -- this is configured
+    in the webapp's Team Settings section.
+
+    ```
+    g.invite_light_user("user1@example.com")
+
+    ```
+
+    Args:
+      email (str): The email address of the user to add to the team.
+    
+    Returns:
+      response (str): parsed JSON response.
+      status (int): response status code
+    """
+
+    res, status = self.__invite_user(email, is_light_user=True)
+    # todo: return a dict that maps email -> bool indicating if the user was invited successfully.
+    return res, status
+  
+  def invite_core_user(self, email, *groups):
+    """
+    Adds a user to the team as a core user and adds them to the groups provided.
+    The user may receive an email because of this -- this is configured
+    in the webapp's Team Settings section.
+
+    If the user is already on the team this still adds them to the
+    groups.
+
+    ```
+    g.invite_core_user("user1@example.com")
+
+    # invite a user and add them to some groups.
+    g.invite_core_user("user2@example.com", "Experts", "Engineering")
+    ```
+
+    Args:
+      email (str): The email address of the user to add to the team.
+      *groups (str): Any number of groups to add the user to.
+    
+    Returns:
+      response (str): parsed JSON response.
+      status (int): response status code
+    """
+    
+    res, status = self.__invite_user(email, *groups)
+
+    return res, status
+
+  def upgrade_light_user(self, email):
+    """
+    Upgrades a light user to a core user.
+
+    ```
+    g.upgrade_light_user("user1@example.com")
+    ```
+
+    Args:
+      email (str): The email address of the light user.
+    Returns:
       todo: fill this out.
     """
-    groups = list(groups)
 
-    if not is_email(email):
-      raise ValueError("invalid email '%s'" % email)
-    
-    if groups:
-      self.__log("invite user", make_blue(email), "and then add them to:", make_blue(groups))
-    else:
-      self.__log("invite user", make_blue(email))
-    
-    data = { "emails": email }
-    url = "%s/members/invite" % self.base_url
+    # check if user is Light user first, then upgrade
+
+    # load the user list so we can check if any of these assignments were already made.
+    users = self.get_members(email, cache=False)
+    user = find_by_email(users, email)
+
+    if not user:
+      self.__log(make_red("could not find user:", email))
+      return
+
+    if user.access_type != "READ_ONLY" and user.billing_type != "FREE":
+      self.__log(make_red("user is not a light user:", email))
+      return
+  
+    data = {}
+    url = "%s/members/%s/upgrade/" % (self.base_url, email)
     response = self.__post(url, data)
 
-    # if there are remaining groups, call add_user_to_groups() for that.
-    if groups:
-      # todo: when we call this, it'll make a GET call to load this user to see if they're
-      #       already in any of the groups we're trying to add them to -- in this case, since
-      #       we _just_ invited them, we know they won't be. it'd be great to be able to skip
-      #       that GET call in this situation.
-      self.add_user_to_groups(email, *groups)
-    
-    # todo: return a dict that maps email -> bool indicating if the user was invited successfully.
-    return response.json(), response.status_code
+    return response.json(), response.status_code 
   
   def add_users_to_group(self, emails, group):
     """

--- a/guru/core.py
+++ b/guru/core.py
@@ -775,7 +775,8 @@ class Guru:
     Args:
       email (str): The email address of the light user.
     Returns:
-      todo: fill this out.
+      response (str): parsed JSON response.
+      status (int): response status code
     """
 
     # check if user is Light user first, then upgrade
@@ -794,6 +795,41 @@ class Guru:
   
     data = {}
     url = "%s/members/%s/upgrade/" % (self.base_url, email)
+    response = self.__post(url, data)
+
+    return response.json(), response.status_code 
+  
+  def downgrade_core_user(self, email):
+    """
+    Downgrades a core user to a light user.
+
+    ```
+    g.downgrade_core_user("user1@example.com")
+    ```
+
+    Args:
+      email (str): The email address of the core user.
+    Returns:
+      response (str): parsed JSON response.
+      status (int): response status code
+    """
+
+    # check if user is Light user first, then upgrade
+
+    # load the user list so we can check if any of these assignments were already made.
+    users = self.get_members(email, cache=False)
+    user = find_by_email(users, email)
+
+    if not user:
+      self.__log(make_red("could not find user:", email))
+      return
+
+    if user.access_type != "CORE" and user.billing_type != "CORE":
+      self.__log(make_red("user is not a core user:", email))
+      return
+  
+    data = {}
+    url = "%s/members/%s/downgrade/" % (self.base_url, email)
     response = self.__post(url, data)
 
     return response.json(), response.status_code 

--- a/guru/core.py
+++ b/guru/core.py
@@ -781,7 +781,7 @@ class Guru:
 
     # check if user is Light user first, then upgrade
 
-    # load the user list so we can check if any of these assignments were already made.
+    # load the user list so we can check if the user is a member and a light user.
     users = self.get_members(email, cache=False)
     user = find_by_email(users, email)
 
@@ -814,9 +814,9 @@ class Guru:
       status (int): response status code
     """
 
-    # check if user is Light user first, then upgrade
+    # check if user is Core user first, then downgrade
 
-    # load the user list so we can check if any of these assignments were already made.
+    # load the user list so we can check if the user is a member and a core user.
     users = self.get_members(email, cache=False)
     user = find_by_email(users, email)
 
@@ -931,7 +931,11 @@ class Guru:
     if not user:
       self.__log(make_red("could not find user:", email))
       return
-  
+
+    if user.access_type == "READ_ONLY" and user.billing_type == "FREE":
+      self.__log(make_red("user is a light user, and cannot belong to groups:", email))
+      return
+
     # for each group, track whether the addition was successful or not.
     result = {}
     for group in groups:

--- a/guru/core.py
+++ b/guru/core.py
@@ -642,7 +642,7 @@ class Guru:
     users = [User(u) for u in users]
     return users
 
-  def __invite_user(self, email, is_light_user=False, *groups):
+  def __invite_user(self, email, *groups, is_light_user=False):
     """
     Internal
 
@@ -794,7 +794,7 @@ class Guru:
       return
   
     data = {}
-    url = "%s/members/%s/upgrade/" % (self.base_url, email)
+    url = "%s/members/%s/upgrade" % (self.base_url, email)
     response = self.__post(url, data)
 
     return response.json(), response.status_code 
@@ -829,7 +829,7 @@ class Guru:
       return
   
     data = {}
-    url = "%s/members/%s/downgrade/" % (self.base_url, email)
+    url = "%s/members/%s/downgrade" % (self.base_url, email)
     response = self.__post(url, data)
 
     return response.json(), response.status_code 

--- a/guru/core.py
+++ b/guru/core.py
@@ -731,9 +731,9 @@ class Guru:
       status (int): response status code
     """
 
-    res, status = self.__invite_user(email, is_light_user=True)
+    response, status = self.__invite_user(email, is_light_user=True)
     # todo: return a dict that maps email -> bool indicating if the user was invited successfully.
-    return res, status
+    return response, status
   
   def invite_core_user(self, email, *groups):
     """
@@ -760,9 +760,9 @@ class Guru:
       status (int): response status code
     """
     
-    res, status = self.__invite_user(email, *groups)
+    response, status = self.__invite_user(email, *groups)
 
-    return res, status
+    return response, status
 
   def upgrade_light_user(self, email):
     """

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -568,11 +568,14 @@ class User:
 
   def __init__(self, data):
     user_obj = data.get("user") or data or {}
+    user_attr = data.get("userAttributes")
     self.email = user_obj.get("email")
     self.first_name = user_obj.get("firstName")
     self.last_name = user_obj.get("lastName")
     self.image = user_obj.get("profilePicUrl")
     self.status = user_obj.get("status")
+    self.billing_type = user_attr.get("BILLING_TYPE")
+    self.access_type = user_attr.get("ACCESS_TYPE")
     self.groups = [Group(group) for group in data.get("groups", [])]
 
   @property

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -568,7 +568,7 @@ class User:
 
   def __init__(self, data):
     user_obj = data.get("user") or data or {}
-    user_attr = data.get("userAttributes")
+    user_attr = data.get("userAttributes", {})
     self.email = user_obj.get("email")
     self.first_name = user_obj.get("firstName")
     self.last_name = user_obj.get("lastName")

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -590,6 +590,16 @@ class User:
     else:
       return self.email
 
+  @property
+  def is_light(self):
+    """Boolean telling if user is a light user"""
+    return self.access_type == "READ_ONLY" and self.billing_type == "FREE"
+  
+  @property
+  def is_core(self):
+    """Boolean telling if user is a core user"""
+    return self.access_type == "CORE" and self.billing_type == "CORE"
+
   def has_group(self, group):
     """
     Returns True if the user is a member of the specified group.

--- a/tests/test_core_users.py
+++ b/tests/test_core_users.py
@@ -228,6 +228,31 @@ class TestCore(unittest.TestCase):
 
   @use_guru()
   @responses.activate
+  def test_add_light_user_to_group(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
+      "user": {"email": "user@example.com"},
+      "userAttributes": {
+        "BILLING_TYPE": "FREE",
+        "ACCESS_TYPE": "READ_ONLY"
+      }
+    }])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
+      "id": "1234",
+      "name": "Experts"
+    }])
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/groups/1234/members")
+
+    result = g.add_user_to_group("user@example.com", "Experts")
+    
+    self.assertIsNone(result)
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
+    }])
+    
+
+  @use_guru()
+  @responses.activate
   def test_add_user_to_invalid_group(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},

--- a/tests/test_core_users.py
+++ b/tests/test_core_users.py
@@ -21,8 +21,90 @@ class TestCore(unittest.TestCase):
       "method": "POST",
       "url": "https://api.getguru.com/api/v1/members/invite",
       "body": {
-        "emails": "user@example.com"
+        "emails": "user@example.com",
+        "teamMemberType": "CORE"
       }
+    }])
+  
+  @use_guru()
+  @responses.activate
+  def test_invite_core_user(self, g):
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/invite", json={})
+
+    g.invite_core_user("user@example.com")
+
+    self.assertEqual(get_calls(), [{
+      "method": "POST",
+      "url": "https://api.getguru.com/api/v1/members/invite",
+      "body": {
+        "emails": "user@example.com",
+        "teamMemberType": "CORE"
+      }
+    }])
+  
+  @use_guru()
+  @responses.activate
+  def test_invite_light_user(self, g):
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/invite", json={})
+
+    g.invite_light_user("user@example.com")
+
+    self.assertEqual(get_calls(), [{
+      "method": "POST",
+      "url": "https://api.getguru.com/api/v1/members/invite",
+      "body": {
+        "emails": "user@example.com",
+        "teamMemberType": "LIGHT"
+      }
+    }])
+  
+  @use_guru()
+  @responses.activate
+  def test_upgrade_light_user(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
+      "id": "user@example.com",
+      "user": {"email": "user@example.com"},
+      "userAttributes": {
+        "BILLING_TYPE": "FREE",
+        "ACCESS_TYPE": "READ_ONLY"
+      }
+    }])
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/user@example.com/upgrade", json={})
+
+    g.upgrade_light_user("user@example.com")
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
+    }, {
+      "method": "POST",
+      "url": "https://api.getguru.com/api/v1/members/user@example.com/upgrade",
+      "body": {}
+    }])
+  
+  @use_guru()
+  @responses.activate
+  def test_downgrade_core_user(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
+      "id": "user@example.com",
+      "user": {"email": "user@example.com"},
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
+    }])
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/user@example.com/downgrade", json={})
+
+    g.downgrade_core_user("user@example.com")
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
+    }, {
+      "method": "POST",
+      "url": "https://api.getguru.com/api/v1/members/user@example.com/downgrade",
+      "body": {}
     }])
   
   @use_guru()
@@ -38,7 +120,11 @@ class TestCore(unittest.TestCase):
     responses.add(responses.POST, "https://api.getguru.com/api/v1/members/invite", json={})
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
-      "groups": []
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
     responses.add(responses.POST, "https://api.getguru.com/api/v1/groups/1234/members")
     responses.add(responses.POST, "https://api.getguru.com/api/v1/groups/5678/members")
@@ -49,7 +135,9 @@ class TestCore(unittest.TestCase):
       "method": "POST",
       "url": "https://api.getguru.com/api/v1/members/invite",
       "body": {
-        "emails": "user@example.com"
+        "emails": "user@example.com",
+        "teamMemberType": "CORE"
+
       }
     }, {
       "method": "GET",
@@ -81,7 +169,11 @@ class TestCore(unittest.TestCase):
     responses.add(responses.POST, "https://api.getguru.com/api/v1/members/invite", json={})
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
-      "groups": []
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
 
     g.invite_user("user@example.com", "other group")
@@ -90,7 +182,8 @@ class TestCore(unittest.TestCase):
       "method": "POST",
       "url": "https://api.getguru.com/api/v1/members/invite",
       "body": {
-        "emails": "user@example.com"
+        "emails": "user@example.com",
+        "teamMemberType": "CORE"
       }
     }, {
       "method": "GET",
@@ -105,7 +198,11 @@ class TestCore(unittest.TestCase):
   def test_add_user_to_group(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
-      "groups": []
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "id": "1234",
@@ -134,7 +231,11 @@ class TestCore(unittest.TestCase):
   def test_add_user_to_invalid_group(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
-      "groups": []
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "id": "1234",
@@ -156,7 +257,11 @@ class TestCore(unittest.TestCase):
   def test_add_user_to_groups(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
-      "groups": []
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "id": "1234",
@@ -195,7 +300,11 @@ class TestCore(unittest.TestCase):
   def test_add_user_to_groups_where_first_one_is_invalid(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
-      "groups": []
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "id": "5678",
@@ -229,7 +338,11 @@ class TestCore(unittest.TestCase):
   def test_add_user_to_groups_where_second_one_is_invalid(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
       "user": {"email": "user@example.com"},
-      "groups": []
+      "groups": [],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "id": "1234",
@@ -278,7 +391,11 @@ class TestCore(unittest.TestCase):
       "groups": [{
         "id": "1111",
         "name": "Experts"
-      }]
+      }],
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
     }])
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "id": "1111",

--- a/tests/test_core_users.py
+++ b/tests/test_core_users.py
@@ -61,50 +61,80 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_upgrade_light_user(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
-      "id": "user@example.com",
-      "user": {"email": "user@example.com"},
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=light%40example.com", json=[{
+      "id": "light@example.com",
+      "user": {"email": "light@example.com"},
       "userAttributes": {
         "BILLING_TYPE": "FREE",
         "ACCESS_TYPE": "READ_ONLY"
       }
     }])
-    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/user@example.com/upgrade", json={})
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=core%40example.com", json=[{
+      "id": "core@example.com",
+      "user": {"email": "core@example.com"},
+      "userAttributes": {
+        "BILLING_TYPE": "CORE",
+        "ACCESS_TYPE": "CORE"
+      }
+    }])
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/light@example.com/upgrade", json={})
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/core@example.com/upgrade", json={})
 
-    g.upgrade_light_user("user@example.com")
+    light_user_result = g.upgrade_light_user("light@example.com")
+    core_user_result = g.upgrade_light_user("core@example.com")
 
+    self.assertEqual(light_user_result, True)
+    self.assertIsNone(core_user_result)
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=light%40example.com"
     }, {
       "method": "POST",
-      "url": "https://api.getguru.com/api/v1/members/user@example.com/upgrade",
+      "url": "https://api.getguru.com/api/v1/members/light@example.com/upgrade",
       "body": {}
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/members?search=core%40example.com"
     }])
   
   @use_guru()
   @responses.activate
   def test_downgrade_core_user(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=user%40example.com", json=[{
-      "id": "user@example.com",
-      "user": {"email": "user@example.com"},
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=core%40example.com", json=[{
+      "id": "core@example.com",
+      "user": {"email": "core@example.com"},
       "groups": [],
       "userAttributes": {
         "BILLING_TYPE": "CORE",
         "ACCESS_TYPE": "CORE"
       }
     }])
-    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/user@example.com/downgrade", json={})
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/members?search=light%40example.com", json=[{
+      "id": "light@example.com",
+      "user": {"email": "light@example.com"},
+      "userAttributes": {
+        "BILLING_TYPE": "FREE",
+        "ACCESS_TYPE": "READ_ONLY"
+      }
+    }])
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/core@example.com/downgrade", json={})
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/members/light@example.com/downgrade", json={})
 
-    g.downgrade_core_user("user@example.com")
+    core_user_result = g.downgrade_core_user("core@example.com")
+    light_user_result = g.downgrade_core_user("light@example.com")
 
+    self.assertEqual(core_user_result, True)
+    self.assertIsNone(light_user_result)
     self.assertEqual(get_calls(), [{
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/members?search=user%40example.com"
+      "url": "https://api.getguru.com/api/v1/members?search=core%40example.com"
     }, {
       "method": "POST",
-      "url": "https://api.getguru.com/api/v1/members/user@example.com/downgrade",
+      "url": "https://api.getguru.com/api/v1/members/core@example.com/downgrade",
       "body": {}
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/members?search=light%40example.com"
     }])
   
   @use_guru()


### PR DESCRIPTION
CH Ticket: https://app.clubhouse.io/guru/story/60389/add-light-users-to-the-sdk

## Overview

This PR adds the ability to invite users as light users, upgrade them to core users, and downgrade core users to light users. 
Adding this functionality called for updating the `User` object, with new properties that are returned from the API.

The user_management example has also been updated, to give example usage of the light user features.

In an effort to not break usage of the existing `invite_users` method, `invite_user` now calls an internal `__invite_user`, as that functionality is shared amongst `invite_user`, `invite_core_user`, and `invite_light_user`.