### PR TITLE
update clean_up_html to allow for guru markdown blocks in card content

### DIFF
--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -164,14 +164,11 @@ def clean_up_html(html):
       else:
         block.insert_after("[[GURU[[%s]]GURU]]" % tag)
 
-  # look for ul > ul and unwrap the child ul.
-  for child_ul in doc.select("ul > ul"):
-    child_ul.unwrap()
-
-  # remove empty ol and ul tags.
-  for ol in doc.select("ol, ul"):
-    if len(ol.select("li")) == 0:
-      ol.decompose()
+  # look for things like ul > ul and unwrap the child list.
+  # we expect nested lists to be wrapped in an <li> and if they're not,
+  # it introduces an extra blank list item when it's viewed in guru.
+  for child_list in doc.select("ul > ul, ul > ol, ol > ol, ol > ul"):
+    child_list.unwrap()
 
   # remove unnecessary things from style attributes (e.g. width/height on table cells).
   style_attrs_to_keep = [
@@ -211,13 +208,18 @@ def clean_up_html(html):
   #  - contain either no tags, or contains only br, div, or span tags.
   #
   # the second rule is important otherwise we'll remove paragraphs that contain only an image, iframe, etc.
-  for el in doc.select("p, h1, h2, h3, h4, h5, h6"):
+  for el in doc.select("p, li, h1, h2, h3, h4, h5, h6"):
     text = el.text.strip()
     if not text:
       all_tag_count = len(el.select("*"))
       unimportant_tag_count = len(el.select("br, div, span"))
       if all_tag_count == unimportant_tag_count:
         el.decompose()
+
+  # remove empty ol and ul tags.
+  for ol in doc.select("ol, ul"):
+    if len(ol.select("li")) == 0:
+      ol.decompose()
 
   return (
     str(doc)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -802,11 +802,12 @@ class TestBundle(unittest.TestCase):
   <a name="test">no href</a>
 </p>
 <p><br></p>
+<ul><ul><li>test</li><li><ol></ol></li></ul></ul>
 <nav><img src="https://www.example.com/test"/></nav>
-<table>
+<table class="test ghq-table other-class">
   <caption>test</caption>
   <tr>
-    <td data-something="5">
+    <td data-something="5" class="this-gets-removed">
       <p>test</p>
       <ul>
         <li>One</li>
@@ -835,8 +836,9 @@ class TestBundle(unittest.TestCase):
 <a href="mailto:user@example.com">user@example.com</a>
 <a>no href</a>
 </p>
+<ul><li>test</li><li></li></ul>
 <img src="https://www.example.com/test"/>
-<table>
+<table class="ghq-table">
 <tr>
 <td>
 <p>test</p>
@@ -1457,26 +1459,34 @@ it's multiple lines
   <li>
     test
   </li>
-  <ol>
-    <li>
-      one
-    </li>
-    <li>
-      two
-    </li>
-  </ol>
-  <ul>
+  <li>
     <ol>
       <li>
-        iframe:​ ​<iframe src="https://www.example.com"></iframe>
+        one
+      </li>
+      <li>
+        two
       </li>
     </ol>
-  </ul>
-  <ol>
-    <li>
-      three
-    </li>
-  </ol>
+  </li>
+  <li>
+    <ul>
+      <li>
+        <ol>
+          <li>
+            iframe:​ ​<iframe src="https://www.example.com"></iframe>
+          </li>
+        </ol>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <ol>
+      <li>
+        three
+      </li>
+    </ol>
+  </li>
   <li>
     end
   </li>
@@ -1486,26 +1496,34 @@ it's multiple lines
 <li>
     test
   </li>
+<li>
 <ol>
 <li>
-      one
-    </li>
+        one
+      </li>
 <li>
-      two
-    </li>
+        two
+      </li>
 </ol>
+</li>
+<li>
 <ul>
+<li>
 <ol>
 <li>
-        iframe:​ ​</li></ol></ul></ul><iframe src="https://www.example.com"></iframe><ul><ul><ol start="2"><li>
+            iframe:​ ​</li></ol></li></ul></li></ul><iframe src="https://www.example.com"></iframe><ul><li><ul><li><ol start="2"><li>
 </li>
 </ol>
+</li>
 </ul>
+</li>
+<li>
 <ol>
 <li>
-      three
-    </li>
+        three
+      </li>
 </ol>
+</li>
 <li>
     end
   </li>
@@ -1648,3 +1666,32 @@ it's multiple lines
 <a href="https://www.example.com/removed_card">removed card</a>
 <a href="">link with no href</a>
 </p>""")
+
+  @use_guru()
+  def test_guru_markdown_blocks(self, g):
+    bundle = g.bundle("test_guru_markdown_blocks")
+
+    # make sure the attributes on the markdown block's div are preserved and
+    # that style attributes on elements inside the markdown are left alone.
+    node1 = bundle.node(id="1", url="https://www.example.com/1", title="node 1", content="""<div class="ghq-card-content__markdown" data-ghq-card-content-markdown-content="%3Cdiv%20style%3D%22background-color%3A%23F89E91%3Bcolor%3A%234A1717%3Bpadding%3A1px%3Btext-align%3Aleft%3Bfont-size%3A16px%3Bmargin-bottom%3A16px%22%3E%0A%3Cp%20style%3D%22margin%3A%2016px%22%3Etest%20content%20%3Cstrong%3Eabcd%201234.%3C%2Fstrong%3E%3C%2Fp%3E%0A%3C%2Fdiv%3E" data-ghq-card-content-type="MARKDOWN">
+	<div style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px" class="">
+		<p style="margin: 16px" class="">
+			test content
+			<strong>
+				abcd 1234.
+			</strong>
+		</p>
+	</div>
+</div>""")
+    bundle.zip()
+
+    self.assertEqual(read_html("/tmp/test_guru_markdown_blocks/cards/1.html"), """<div class="ghq-card-content__markdown" data-ghq-card-content-markdown-content="%3Cdiv%20style%3D%22background-color%3A%23F89E91%3Bcolor%3A%234A1717%3Bpadding%3A1px%3Btext-align%3Aleft%3Bfont-size%3A16px%3Bmargin-bottom%3A16px%22%3E%0A%3Cp%20style%3D%22margin%3A%2016px%22%3Etest%20content%20%3Cstrong%3Eabcd%201234.%3C%2Fstrong%3E%3C%2Fp%3E%0A%3C%2Fdiv%3E" data-ghq-card-content-type="MARKDOWN">
+<div class="" style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px">
+<p class="" style="margin: 16px">
+			test content
+			<strong>
+				abcd 1234.
+			</strong>
+</p>
+</div>
+</div>""")

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1695,3 +1695,16 @@ it's multiple lines
 </p>
 </div>
 </div>""")
+
+  @use_guru()
+  def test_removing_empty_lists_and_list_items(self, g):
+    bundle = g.bundle("test_removing_empty_lists_and_list_items")
+
+    # the ul contains an image, so one li is removed but the list remains.
+    # the ol only contains an li that'll be removed, so we expect the ol to be removed too.
+    html = """<ul><li><br/></li><li><img src="https://www.example.com/test.png"/></li></ul><ol><li><br/></li></ol>"""
+    new_html = """<ul><li><img src="https://www.example.com/test.png"/></li></ul>"""
+    node1 = bundle.node(id="1", title="node 1", content=html)
+    bundle.zip()
+
+    self.assertEqual(read_html("/tmp/test_removing_empty_lists_and_list_items/cards/1.html"), new_html)

--- a/tests/test_core_groups_and_collections.py
+++ b/tests/test_core_groups_and_collections.py
@@ -401,6 +401,31 @@ class TestCore(unittest.TestCase):
 
   @use_guru()
   @responses.activate
+  def test_get_group_members_edge_cases(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
+      "name": "Experts",
+      "id": "1111"
+    }])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/groups/1111/members", status=204)
+
+    result1 = g.get_group_members("Doesn't Exist")
+    result2 = g.get_group("Experts").get_members()
+
+    self.assertEqual(result1, False)
+    self.assertEqual(result2, [])
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/groups"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/groups"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/groups/1111/members"
+    }])
+
+  @use_guru()
+  @responses.activate
   def test_delete_group(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "id": "1111",


### PR DESCRIPTION
There are a few attributes we need to allow for Guru markdown blocks to work, so we don't want to remove those when we clean up HTML -- both the attributes on the markdown div and any style attributes on elements inside the markdown block.

There's also some cleanup for lists where other systems create nested lists by having `ul` tags as direct children of other `ul` tags. This might render correctly outside guru but it creates an extra bullet point at the start of the list.