### PR TITLE
handle tables better

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -808,6 +808,7 @@ class TestBundle(unittest.TestCase):
   <caption>test</caption>
   <tr>
     <td data-something="5" class="this-gets-removed">
+      <h2>heading</h2>
       <p>test</p>
       <ul>
         <li>One</li>
@@ -841,7 +842,9 @@ class TestBundle(unittest.TestCase):
 <table class="ghq-table">
 <tr>
 <td>
-<p>test</p>
+<strong>heading</strong>
+<br/>test
+
 <br/>- One
 <br/>- Two
 


### PR DESCRIPTION
This adds two things:

1. Handling colspan attributes by inserting extra cells. I don't think our editor handles this well and it might insert all the necessary extra cells at the end of the row, so if you have something like:

```
<tr>
  <td colspan="2">A</td>
  <td colspan="2">B</td>
</tr>
<tr>
  <td>1</td>
  <td>2</td>
  <td>3</td>
  <td>4</td>
</tr>
```

Previously you'd end up with A, B, then two blank cells, so B would be over top of 2. By inserting extra `<td>`s you get: A, blank cell, B, blank cell, so B lines up with 3 still.

2. It also looks for other block elements that might be inside table cells and converts them to inlines. We already did this for lists but we would also have problems if the td contained a paragraph then a list, or a heading and a paragraph, or even just two paragraphs.