### PR TITLE
Bug/johnchappelle/ch62572/fix check in download func to find status

### DIFF
--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -774,15 +774,15 @@ class BundleNode:
           filename = self.bundle.RESOURCE_PATH % (self.bundle.id, resource_id)
           self.bundle.log(message="checking if we should download attachment", url=absolute_url, file=filename)
 
-          # you can either return True or return the http status code.
+          # you can either return True or return a tuple, with the http status code as the first item.
           # if the file was downloaded we need to update the src/href.
           download_result = download_func(absolute_url, filename, self.bundle, self)
 
           is_successful = False
           if type(download_result) == type(True):
             is_successful = download_result
-          elif isinstance(download_result, int):
-            if int(download_result / 100) == 2:
+          elif download_result and isinstance(download_result[0], int):
+            if int(download_result[0] / 100) == 2:
               is_successful = True
 
           if is_successful:

--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -775,6 +775,7 @@ class BundleNode:
           self.bundle.log(message="checking if we should download attachment", url=absolute_url, file=filename)
 
           # you can either return True or return a tuple, with the http status code as the first item.
+          # if the file didn't download, you would get a return of False or None.
           # if the file was downloaded we need to update the src/href.
           download_result = download_func(absolute_url, filename, self.bundle, self)
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -731,7 +731,7 @@ class TestBundle(unittest.TestCase):
 </p>""")
 
     download_mock = Mock()
-    download_mock.return_value = 200
+    download_mock.return_value = (200, 2355)
     sync.zip(download_func=download_mock)
 
     self.assertEqual(download_mock.call_args.args, (


### PR DESCRIPTION
CH ticket: https://app.clubhouse.io/guru/story/62572/fix-check-in-download-func-to-find-status-code-in-tuple

## Overview

When we download a file for adding to a bundle, we used to just return a status code or status_to_bool from the result, from the download_func, but we now return a tuple ( status, filesize ). If the `html_cleanup` method misses this step, the resource's link in the html doesn't get updated to point to the resource in the `/resources` directory. This PR updates that line of code and updates tests that checked for just a status code return.