### PR TITLE
add delete board to SDK

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -2419,6 +2419,39 @@ class Guru:
     response = self.__put(url, data)
     return status_to_bool(response.status_code)
 
+  def delete_board(self, board, collection=None):
+    """
+    deletes board
+
+    Args:
+        board (str or Board): The name or ID of a board or a Board object
+
+        collection (str or Collection, optional): The name or ID of a collection or a Collection object
+          to filter by. If this is not provided, you'll get back a list of all boards in all collections
+          you can see.
+
+    Returns:
+        bool: True if it was successful and False otherwise.
+    """
+
+    if isinstance(board, Board):
+      url = "%s/boards/%s" % (self.base_url, board.id)
+      response = self.__delete(url)
+      return status_to_bool(response.status_code)
+
+
+    board_obj = find_by_name_or_id(self.get_boards(collection), board)
+    
+    if not board_obj:
+      self.__log(make_red("could not find board:", board))
+      return
+
+
+    url = "%s/boards/%s" % (self.base_url, board_obj.id)
+    response = self.__delete(url)
+    return status_to_bool(response.status_code)
+
+
   def bundle(self, id="default", clear=True, folder="/tmp/", verbose=False, skip_empty_sections=False):
     """
     Creates a Bundle object that can be used to bulk import content.

--- a/guru/core.py
+++ b/guru/core.py
@@ -66,7 +66,7 @@ def base64_encode(string):
   ).decode("ascii")
 
 def is_board_slug(value):
-  return re.match("^[a-zA-Z0-9]{5,8}$", value)
+  return re.match("^[a-zA-Z0-9]{8,9}$", value)
 
 def is_uuid(value):
   return re.match("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", value, flags=re.IGNORECASE)
@@ -2535,13 +2535,7 @@ class Guru:
         bool: True if it was successful and False otherwise.
     """
 
-    if isinstance(board, Board):
-      url = "%s/boards/%s" % (self.base_url, board.id)
-      response = self.__delete(url)
-      return status_to_bool(response.status_code)
-
-
-    board_obj = find_by_name_or_id(self.get_boards(collection), board)
+    board_obj = self.get_board(board, collection=collection)
     
     if not board_obj:
       self.__log(make_red("could not find board:", board))

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -295,6 +295,15 @@ class Board:
         new collection.
     """
     self.guru.move_board_to_collection(self, collection, timeout)
+  
+  def delete(self):
+    """
+    deletes board
+
+    Returns:
+      bool: True if it was successful and False otherwise.
+    """
+    return self.guru.delete_board(self, self.collection.id)
 
   def json(self, include_items=True, include_item_id=False, include_collection=True):
     data = {

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1689,8 +1689,8 @@ it's multiple lines
     bundle.zip()
 
     self.assertEqual(read_html("/tmp/test_guru_markdown_blocks/cards/1.html"), """<div class="ghq-card-content__markdown" data-ghq-card-content-markdown-content="%3Cdiv%20style%3D%22background-color%3A%23F89E91%3Bcolor%3A%234A1717%3Bpadding%3A1px%3Btext-align%3Aleft%3Bfont-size%3A16px%3Bmargin-bottom%3A16px%22%3E%0A%3Cp%20style%3D%22margin%3A%2016px%22%3Etest%20content%20%3Cstrong%3Eabcd%201234.%3C%2Fstrong%3E%3C%2Fp%3E%0A%3C%2Fdiv%3E" data-ghq-card-content-type="MARKDOWN">
-<div style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px">
-<p style="margin: 16px">
+<div class="" style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px">
+<p class="" style="margin: 16px">
 			test content
 			<strong>
 				abcd 1234.

--- a/tests/test_core_boards.py
+++ b/tests/test_core_boards.py
@@ -497,6 +497,7 @@ class TestCore(unittest.TestCase):
       "id": "1234",
       "name": "General"
     }])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/isinvalid", status=404)
     responses.add(responses.GET, "https://api.getguru.com/api/v1/boards?collection=1234", json=[{
       "id": "abcd",
       "title": "Board A",
@@ -505,9 +506,12 @@ class TestCore(unittest.TestCase):
       "title": "Board B"
     }])
 
-    g.set_item_order("General", "invalid", "a", "b", "c")
+    g.set_item_order("General", "isinvalid", "a", "b", "c")
 
     self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards/isinvalid"
+    }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/collections",
     }, {
@@ -1331,16 +1335,20 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_move_invalid_board_to_collection(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/11111111", status=404)
     responses.add(responses.GET, "https://api.getguru.com/api/v1/collections", json=[{
       "id": "1234",
       "name": "General"
     }])
     responses.add(responses.GET, "https://api.getguru.com/api/v1/boards?collection=1234", json=[])
 
-    result = g.move_board_to_collection("11111", "General")
+    result = g.move_board_to_collection("11111111", "General")
 
     self.assertEqual(result, None)
     self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards/11111111"
+    }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/collections"
     }, {

--- a/tests/test_core_boards.py
+++ b/tests/test_core_boards.py
@@ -76,6 +76,39 @@ class TestCore(unittest.TestCase):
 
   @use_guru()
   @responses.activate
+  def test_delete_board(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards", json=[{
+      "id": "abcd",
+      "title": "General"
+    }])
+    responses.add(responses.DELETE, "https://api.getguru.com/api/v1/boards/abcd")
+
+    g.delete_board("General")
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards"
+    }, {
+      "method": "DELETE",
+      "url": "https://api.getguru.com/api/v1/boards/abcd"
+    }])
+  
+  @use_guru()
+  @responses.activate
+  def test_delete_board_with_invalid_board(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards", json=[])
+    responses.add(responses.DELETE, "https://api.getguru.com/api/v1/boards/abcd")
+
+    g.delete_board("General")
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards"
+    }])
+
+
+  @use_guru()
+  @responses.activate
   def test_get_board_group(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/collections", json=[{
       "id": "1234",

--- a/tests/test_core_boards.py
+++ b/tests/test_core_boards.py
@@ -148,15 +148,38 @@ class TestCore(unittest.TestCase):
   def test_delete_board(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/boards", json=[{
       "id": "abcd",
-      "title": "General"
+      "title": "General",
+      "collection": {
+        "id": "ababab"
+      }
+    },
+    {
+      "id": "4321",
+      "title": "Test",
+      "collection": {
+        "id": "cdcdcd"
+      }
     }])
+    # responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/General", json={})
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/abcd", json={
+      "id": "abcd",
+      "title": "General",
+      "collection": {
+        "id": "ababab"
+      }
+    })
     responses.add(responses.DELETE, "https://api.getguru.com/api/v1/boards/abcd")
 
-    g.delete_board("General")
+    board = g.get_board("General")
+    board.delete()
+
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/boards"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards/abcd"
     }, {
       "method": "DELETE",
       "url": "https://api.getguru.com/api/v1/boards/abcd"
@@ -168,7 +191,7 @@ class TestCore(unittest.TestCase):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/boards", json=[])
     responses.add(responses.DELETE, "https://api.getguru.com/api/v1/boards/abcd")
 
-    g.delete_board("General")
+    g.delete_board("123456")
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
@@ -474,7 +497,6 @@ class TestCore(unittest.TestCase):
       "id": "1234",
       "name": "General"
     }])
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/invalid", status=404)
     responses.add(responses.GET, "https://api.getguru.com/api/v1/boards?collection=1234", json=[{
       "id": "abcd",
       "title": "Board A",
@@ -486,9 +508,6 @@ class TestCore(unittest.TestCase):
     g.set_item_order("General", "invalid", "a", "b", "c")
 
     self.assertEqual(get_calls(), [{
-      "method": "GET",
-      "url": "https://api.getguru.com/api/v1/boards/invalid"
-    }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/collections",
     }, {
@@ -632,21 +651,21 @@ class TestCore(unittest.TestCase):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1111/extended", json={
       "id": "1111"
     })
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/abcde", json={
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/abcde123", json={
       "id": "2222",
-      "slug": "abcde/my-board",
+      "slug": "abcde123/my-board",
       "title": "my board"
     })
     responses.add(responses.PUT, "https://api.getguru.com/api/v1/boards/2222", json={})
 
-    g.add_card_to_board("1111", "abcde")
+    g.add_card_to_board("1111", "abcde123")
 
     self.assertEqual(get_calls(), [{
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/cards/1111/extended"
     }, {
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/boards/abcde"
+      "url": "https://api.getguru.com/api/v1/boards/abcde123"
     }, {
       "method": "PUT",
       "url": "https://api.getguru.com/api/v1/boards/2222",
@@ -1312,7 +1331,6 @@ class TestCore(unittest.TestCase):
   @use_guru()
   @responses.activate
   def test_move_invalid_board_to_collection(self, g):
-    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/11111", status=404)
     responses.add(responses.GET, "https://api.getguru.com/api/v1/collections", json=[{
       "id": "1234",
       "name": "General"
@@ -1323,9 +1341,6 @@ class TestCore(unittest.TestCase):
 
     self.assertEqual(result, None)
     self.assertEqual(get_calls(), [{
-      "method": "GET",
-      "url": "https://api.getguru.com/api/v1/boards/11111"
-    }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/collections"
     }, {


### PR DESCRIPTION
Story details: https://app.clubhouse.io/guru/story/63786

## Overview

This PR adds `delete_board` to `core.py`, with accompanying tests. I have yet to add an example for this method to `examples.py`, but when I do, I'll add notes that this is not easily reversed, so be sure of the deletion you are making, and test first ( testing card to come soon...)