### PR TITLE
add frameworks to the SDK

### DIFF
--- a/examples/import_framework.py
+++ b/examples/import_framework.py
@@ -1,0 +1,11 @@
+import guru
+
+g = guru.Guru()
+
+# Get the framework that matches the name `Client Support`
+framework = g.get_framework("Client Support", cache=True)
+
+# Import the framework
+new_imported_framework_collection = framework.import_framework()
+print(new_imported_framework_collection.name)
+

--- a/guru/core.py
+++ b/guru/core.py
@@ -15,7 +15,7 @@ else:
   from urlparse import quote
 
 from guru.bundle import Bundle
-from guru.data_objects import Board, BoardGroup, BoardPermission, Card, CardComment, Collection, CollectionAccess, Draft, Group, HomeBoard, Tag, User, Question
+from guru.data_objects import Board, BoardGroup, BoardPermission, Card, CardComment, Collection, CollectionAccess, Draft, Group, HomeBoard, Tag, User, Question, Framework
 from guru.util import download_file, find_by_name_or_id, find_by_email, find_by_id, format_timestamp, TRACKING_HEADERS
 
 # collection colors
@@ -269,6 +269,83 @@ class Guru:
     self.__log_response(response)
     return response
 
+  def get_frameworks(self, cache=False):
+    """
+    Loads a list of available collection frameworks.
+
+    ```
+    frameworks = g.get_frameworks()
+    for framework in frameworks:
+      print(framework.name)
+      print(framework.description)
+    ```
+
+    Args:
+      cache (bool, optional): Tells us whether we should reuse the results
+        from the previous call or not. Defaults to False. Set this to True
+        if it's not likely the set of frameworks has changed since the
+        previous call.
+    
+    Returns:
+      list of Framework: a list of Framework objects.
+    """
+    url = "%s/frameworks" % self.base_url
+    response = self.__get(url, cache)
+    return [Framework(f, guru=self) for f in response.json()]
+
+  def get_framework(self, framework, cache=False):
+    """
+    Loads a collection framework.
+
+    ```
+    framework = g.get_framework("Client Support")
+    print(framework.name)
+    print(framework.collection.description)
+    ```
+
+    Args:
+      framework (str): Either a framework name or ID. If it's a name, it'll
+        return the first matching collection and the comparison is not case
+        sensitive.
+      cache (bool, optional): If we're looking up a framework by name we'll
+        fetch all frameworks and then look for a match in the results and this
+        flag tells us whether we should use the results from the previous
+        /frameworks API call or make a new call. Defaults to False.
+    
+    Returns:
+      Framework: An object representing the framework.
+    """
+    if isinstance(framework, Framework):
+      return framework
+    else:
+      # we compare the name and ID because you can pass either.
+      # and if the names aren't unique, you'll need to pass an ID.
+      return find_by_name_or_id(self.get_frameworks(cache), framework)
+
+  def import_framework(self, framework):
+    """
+    imports a framework, based on the provided Framework's ID
+
+    Args:
+      framework (Framework): an object that represents a framework
+
+    Raises:
+      ValueError: must provide a valid Framework object
+
+    Returns:
+      Collection: an object that represents a collection
+    """
+
+    if isinstance(framework, Framework):
+      self.__log("import collection framework", make_blue(framework.title), "with ", make_blue(self.username), "as Collection Owner")
+      url = "%s/frameworks/import/%s" % (self.base_url, framework.id)
+      response = self.__post(url)
+      return Collection(response.json(), guru=self)
+    else:
+      raise ValueError("invalid value: %s, please provide a Framework object." % framework)
+
+
+
   def get_collection(self, collection, cache=False):
     """
     Loads a collection.
@@ -324,7 +401,7 @@ class Guru:
     response = self.__get(url, cache)
     return [Collection(c, guru=self) for c in response.json()]
 
-  def make_collection(self, name, desc="", color=GREEN, is_sync=False, group="All Members", public_cards=True):
+  def make_collection(self, name, desc="", color=GREEN, is_sync=False, group="All Members", public_cards=True, use_framework=False):
     """
     Creates a new collection.
 
@@ -342,10 +419,18 @@ class Guru:
         access to this collection. Defaults to All Members.
       public_cards (bool, optional): True if you want to allow cards in this collection
         to be made public and False if you don't. Defaults to True.
+      use_framework: (bool, optional): True if you are importing a framework. The name parameter will be used to find the 
+        desired framework, so make sure that the name matches the framework you want to use. Defaults to False.
     
     Returns:
       Collection: an object representing the new collection.
     """
+    # if we are importing a framework, we want to handle this a little differently, and use the frameworks endpoint
+    if use_framework:
+      self.__log("import collection framework", make_blue(name), "with ", make_blue(self.username), "as Collection Owner")
+      framework = self.get_framework(name, cache=True)
+      return self.import_framework(framework)
+
     self.__log("make collection", make_blue(name), "with ", make_blue(group), "as Collection Owner")
 
     if not color:

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -550,7 +550,7 @@ class Framework:
     self.name = title
 
   def import_framework(self):
-    return self.guru.make_collection(self.name, use_framework=True)
+    return self.guru.import_framework(self)
   
 class CollectionAccess:
   """

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -528,7 +528,30 @@ class Collection:
       "color": self.color,
     }
 
+class Framework:
+  """
+  The Framework object is used to represent a framework, used to a import as a new collection. 
+  These objects simply have these properties:
+  - `id`
+  - `collection`
+  """
+  def __init__(self, data, guru=None):
+    self.guru = guru
+    self.id = data.get("id")
+    self.name = data.get("collection").get("name")
+    self.collection = Collection(data.get("collection"), guru=guru)
 
+  @property
+  def title(self):
+    return self.name
+
+  @title.setter
+  def title(self, title):
+    self.name = title
+
+  def import_framework(self):
+    return self.guru.make_collection(self.name, use_framework=True)
+  
 class CollectionAccess:
   """
   The CollectionAccess object is used to represent a group's assignment

--- a/tests/test_core_groups_and_collections.py
+++ b/tests/test_core_groups_and_collections.py
@@ -95,7 +95,7 @@ class TestCore(unittest.TestCase):
         "color" : "#2962ff",
         "id" : "12345678-111a-222b-333c-87654321dcba",
         "description" : "Enable your team with: product FAQs, support processes, canned responses, tech stack tips, and more.\n",
-        "slug" : "tjuii/Client-Support",
+        "slug" : "tjuii/Product-and-Process",
         "collectionType" : "INTERNAL",
         "name" : "Product & Process"
       }
@@ -113,11 +113,56 @@ class TestCore(unittest.TestCase):
       "color" : "#2962ff",
       "id" : "12345678-111a-222b-333c-87654321dcba",
       "description" : "Enable your team with: product FAQs, support processes, canned responses, tech stack tips, and more.\n",
-      "slug" : "tjuii/Client-Support",
+      "slug" : "tjuii/Product-and-Process",
       "collectionType" : "INTERNAL",
       "name" : "Product & Process"
     })
     g.make_collection("Product & Process", use_framework=True)
+
+    self.assertEqual(get_calls(), [
+      {
+        "method": "GET",
+        "url": "https://api.getguru.com/api/v1/frameworks"
+      }, {
+        "method": "POST",
+        "url": "https://api.getguru.com/api/v1/frameworks/import/1234"
+      }
+    ])
+
+  @use_guru()
+  @responses.activate
+  def test_get_frameworks_then_make_collection_with_framework(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/frameworks", json=[{
+      "id": "1234",
+      "collection": {
+        "color" : "#2962ff",
+        "id" : "12345678-111a-222b-333c-87654321dcba",
+        "description" : "Enable your team with: product FAQs, support processes, canned responses, tech stack tips, and more.\n",
+        "slug" : "tjuii/Product-and-Process",
+        "collectionType" : "INTERNAL",
+        "name" : "Product & Process"
+      }
+    },{"id": "5678",
+      "collection": {
+        "color" : "#009688",
+        "id" : "56781234-222b-111a-333c-dcba87654321",
+        "description" : "This is just a test.\n",
+        "slug" : "hynw9/Test",
+        "collectionType" : "INTERNAL",
+        "name" : "Test"
+      }
+    }])
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/frameworks/import/1234", json={
+      "color" : "#2962ff",
+      "id" : "12345678-111a-222b-333c-87654321dcba",
+      "description" : "Enable your team with: product FAQs, support processes, canned responses, tech stack tips, and more.\n",
+      "slug" : "tjuii/Product-and-Process",
+      "collectionType" : "INTERNAL",
+      "name" : "Product & Process"
+    })
+    
+    framework = g.get_framework("Product & Process")
+    framework.import_framework()
 
     self.assertEqual(get_calls(), [
       {

--- a/tests/test_core_groups_and_collections.py
+++ b/tests/test_core_groups_and_collections.py
@@ -85,6 +85,49 @@ class TestCore(unittest.TestCase):
         }
       }
     ])
+  
+  @use_guru()
+  @responses.activate
+  def test_make_collection_with_framework(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/frameworks", json=[{
+      "id": "1234",
+      "collection": {
+        "color" : "#2962ff",
+        "id" : "12345678-111a-222b-333c-87654321dcba",
+        "description" : "Enable your team with: product FAQs, support processes, canned responses, tech stack tips, and more.\n",
+        "slug" : "tjuii/Client-Support",
+        "collectionType" : "INTERNAL",
+        "name" : "Product & Process"
+      }
+    },{"id": "5678",
+      "collection": {
+        "color" : "#009688",
+        "id" : "56781234-222b-111a-333c-dcba87654321",
+        "description" : "This is just a test.\n",
+        "slug" : "hynw9/Test",
+        "collectionType" : "INTERNAL",
+        "name" : "Test"
+      }
+    }])
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/frameworks/import/1234", json={
+      "color" : "#2962ff",
+      "id" : "12345678-111a-222b-333c-87654321dcba",
+      "description" : "Enable your team with: product FAQs, support processes, canned responses, tech stack tips, and more.\n",
+      "slug" : "tjuii/Client-Support",
+      "collectionType" : "INTERNAL",
+      "name" : "Product & Process"
+    })
+    g.make_collection("Product & Process", use_framework=True)
+
+    self.assertEqual(get_calls(), [
+      {
+        "method": "GET",
+        "url": "https://api.getguru.com/api/v1/frameworks"
+      }, {
+        "method": "POST",
+        "url": "https://api.getguru.com/api/v1/frameworks/import/1234"
+      }
+    ])
 
   @use_guru()
   @responses.activate


### PR DESCRIPTION
Story details: https://app.clubhouse.io/guru/story/61830

# Overview

This PR introduces importing a collection framework as a templated new collection. To use:

`make_collection("framework title", use_framework=True)`

This PR also adds a `Framework` object, which is like a Collection object, but has an ID that is separate from collection ID:

```
{
  "id" : "a53f3a57-78b3-4fd4-9a99-8e8424060a2d",
  "collection" : {
    "color" : "#2962ff",
    "id" : "126760f9-3533-47e4-88ea-278f8101e663",
    "tags" : 0,
    "description" : "Enable your team with: product FAQs, support processes, canned responses, tech stack tips, and more.\n",
    "contexts" : 0,
    "cards" : 3,
    "roiEnabled" : false,
    "publicCardsEnabled" : false,
    "dateCreated" : "2019-12-27T18:39:27.302+0000",
    "boards" : 1,
    "slug" : "tjuii/Client-Support",
    "publishingEnabled" : false,
    "collectionType" : "INTERNAL",
    "assistEnabled" : false,
    "publicCards" : 0,
    "name" : "Client Support"
  }
}
```
There is also a method on the `Framework` object called `import_framework` which imports that framework into the instance.