### PR TITLE
fix how we remove empty elements

### DIFF
--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -244,13 +244,15 @@ def clean_up_html(html):
   #  - contain either no tags, or contains only br, div, or span tags.
   #
   # the second rule is important otherwise we'll remove paragraphs that contain only an image, iframe, etc.
-  for el in doc.select("p, li, h1, h2, h3, h4, h5, h6"):
-    text = el.text.strip()
-    if not text:
-      all_tag_count = len(el.select("*"))
-      unimportant_tag_count = len(el.select("br, div, span"))
-      if all_tag_count == unimportant_tag_count:
-        el.decompose()
+  elements_to_remove_if_empty = ["p", "li", "h1, h2, h3, h4, h5, h6"]
+  for selector in elements_to_remove_if_empty:
+    for el in doc.select(selector):
+      text = el.text.strip()
+      if not text:
+        all_tag_count = len(el.select("*"))
+        unimportant_tag_count = len(el.select("br, div, span"))
+        if all_tag_count == unimportant_tag_count:
+          el.decompose()
 
   # remove empty ol and ul tags.
   for ol in doc.select("ol, ul"):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1689,8 +1689,8 @@ it's multiple lines
     bundle.zip()
 
     self.assertEqual(read_html("/tmp/test_guru_markdown_blocks/cards/1.html"), """<div class="ghq-card-content__markdown" data-ghq-card-content-markdown-content="%3Cdiv%20style%3D%22background-color%3A%23F89E91%3Bcolor%3A%234A1717%3Bpadding%3A1px%3Btext-align%3Aleft%3Bfont-size%3A16px%3Bmargin-bottom%3A16px%22%3E%0A%3Cp%20style%3D%22margin%3A%2016px%22%3Etest%20content%20%3Cstrong%3Eabcd%201234.%3C%2Fstrong%3E%3C%2Fp%3E%0A%3C%2Fdiv%3E" data-ghq-card-content-type="MARKDOWN">
-<div class="" style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px">
-<p class="" style="margin: 16px">
+<div style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px">
+<p style="margin: 16px">
 			test content
 			<strong>
 				abcd 1234.


### PR DESCRIPTION
I noticed a test was failing because how we remove empty elements was not working. Maybe it broke when we added `li` to this list and all i can figure is there's a problem with iterating over all elements. So, instead of doing `doc.select("p, li, h1, etc.")` to select all elements, we make separate `doc.select()` calls -- one to get p tags, one to get li tags, and one for headings.