### PR TITLE
bulk-load cards when a board has more than 50 cards

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -1097,6 +1097,22 @@ class Guru:
       except:
         return None
 
+  def get_cards(self, card_ids):
+    url = "%s/cards/bulk" % self.base_url
+    data = {
+      "ids": card_ids
+    }
+
+    response = self.__post(url, data)
+
+    # this returns a dict where each key is a card ID and the value
+    # is the card object plus a 'status' field, so we convert the
+    # nested card objects to instances of the Card class.
+    if status_to_bool(response.status_code):
+      return {id: Card(obj) for id, obj in response.json().items()}
+    else:
+      return {}
+
   def get_visible_cards(self):
     """
     Gets the count of all cards on the team where you have read access or higher.

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -90,7 +90,7 @@ class Board:
       self.collection = Collection(data.get("collection"))
     else:
       self.collection = None
-    
+
     self.items = []
     self.__cards = []
     self.__sections = []
@@ -108,6 +108,47 @@ class Board:
         self.items.append(card)
         self.__all_items.append(card)
         self.__cards.append(card)
+
+    self.__load_all_cards()
+
+  def __update_cards_in_list(self, item_list, lookup):
+    # we scan the list and replace any partial card with its full card from the lookup.
+    # we don't bother checking if something is a partial card because if it's in the
+    # lookup dict, that means it must've been a partial card.
+    for i in range(0, len(item_list)):
+      full_item = lookup.get(item_list[i].id)
+      if full_item:
+        item_list[i] = full_item
+
+  def __load_all_cards(self):
+    # identify the partially-loaded cards.
+    # these come from boards that have more than 50 cards.
+    # sometimes the API returns a 'lite' board that doesn't have items at all. these will
+    # naturally skip over most of this logic because their items list is missing or empty
+    # so we don't have any card IDs to try to load.
+    unloaded_card_ids = []
+    for card in self.__cards:
+      if not card.title:
+        unloaded_card_ids.append(card.id)
+
+    # if the board has < 50 cards this list will be empty and we can stop early.
+    if not unloaded_card_ids:
+      return
+
+    # load the unloaded cards in batches of 50.
+    # our API does enforce a max of 50.
+    card_lookup = {}
+    for index in range(0, len(unloaded_card_ids), 50):
+      batch_ids = unloaded_card_ids[index:index + 50]
+      data = self.guru.get_cards(batch_ids)
+      for id in data:
+        card_lookup[id] = data[id]
+
+    # now that we have the full card objects, we update the entries in all the existing lists.
+    self.__update_cards_in_list(self.__cards, card_lookup)
+    self.__update_cards_in_list(self.__all_items, card_lookup)
+    for section in self.__sections:
+      self.__update_cards_in_list(section.items, card_lookup)
 
   @property
   def url(self):

--- a/tests/test_core_boards.py
+++ b/tests/test_core_boards.py
@@ -25,10 +25,12 @@ class TestCore(unittest.TestCase):
         "type": "section",
         "title": "test",
         "items": [{
-          "type": "fact"
+          "type": "fact",
+          "preferredPhrase": "card 1"
         }]
       }, {
-        "type": "fact"
+        "type": "fact",
+        "preferredPhrase": "card 2"
       }]
     })
 
@@ -45,6 +47,73 @@ class TestCore(unittest.TestCase):
     }, {
       "method": "GET",
       "url": "https://api.getguru.com/api/v1/boards/1234"
+    }])
+
+  @use_guru()
+  @responses.activate
+  def test_get_board_with_110_cards(self, g):
+    # we build the list of items that comes back in the initial get call to load the board.
+    # we also build the responses that come back for loading the first page of 50 and the page of 10 cards.
+    board_items = []
+    first_batch = {}
+    second_batch = {}
+    for i in range(110):
+      if i < 50:
+        board_items.append({
+          "type": "fact",
+          "preferredPhrase": "card %s" % i,
+          "id": str(i)
+        })
+      else:
+        board_items.append({
+          "type": "fact",
+          "id": str(i)
+        })
+
+        if i < 100:
+          first_batch[str(i)] = {
+            "preferredPhrase": "card %s" % i
+          }
+        else:
+          second_batch[str(i)] = {
+            "preferredPhrase": "card %s" % i
+          }
+
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards", json=[{
+      "id": "1234",
+      "title": "test"
+    }])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/1234", json={
+      "items": board_items
+    })
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/cards/bulk", json=first_batch)
+    responses.add(responses.POST, "https://api.getguru.com/api/v1/cards/bulk", json=second_batch)
+
+    board = g.get_board("test")
+
+    self.assertEqual(len(board.items), 110)
+    self.assertEqual(len(board.cards), 110)
+    self.assertEqual(board.cards[75].title, "card 75")
+    self.assertEqual(board.cards[105].title, "card 105")
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards/1234"
+    }, {
+      "method": "POST",
+      "url": "https://api.getguru.com/api/v1/cards/bulk",
+      "body": {
+        "ids": [str(i) for i in range(50, 100)]
+      }
+    }, {
+      "method": "POST",
+      "url": "https://api.getguru.com/api/v1/cards/bulk",
+      "body": {
+        "ids": [str(i) for i in range(100, 110)]
+      }
     }])
 
   @use_guru()
@@ -234,18 +303,18 @@ class TestCore(unittest.TestCase):
         "items": [{
           "id": "2",
           "itemId": "i2",
-          "title": "card 1",
+          "preferredPhrase": "card 1",
           "type": "fact"
         }, {
           "id": "3",
           "itemId": "i3",
-          "title": "card 2",
+          "preferredPhrase": "card 2",
           "type": "fact"
         }]
       }, {
         "id": "4",
         "itemId": "i4",
-        "title": "card 3",
+        "preferredPhrase": "card 3",
         "type": "fact"
       }]
     })
@@ -267,11 +336,11 @@ class TestCore(unittest.TestCase):
         "id": "1234", "type": "board", "title": None,
         "collection": {"id": "abcd", "name": "General", "type": None, "color": None},
         "items": [
+          {"type": "fact", "id": "4", "itemId": "i4"},
           {"type": "section", "id": "1", "itemId": "i1", "items": [
             {"type": "fact", "id": "2", "itemId": "i2"},
             {"type": "fact", "id": "3", "itemId": "i3"}
-          ]},
-          {"type": "fact", "id": "4", "itemId": "i4"}
+          ]}
         ]
       }
     }])
@@ -743,7 +812,7 @@ class TestCore(unittest.TestCase):
       "items": [{
         "type": "fact",
         "id": "1111",
-        "title": "my card"
+        "preferredPhrase": "my card"
       }]
     })
     responses.add(responses.PUT, "https://api.getguru.com/api/v1/boards/22222222-2222-2222-2222-222222222222/entries", json={})
@@ -779,7 +848,7 @@ class TestCore(unittest.TestCase):
       "items": [{
         "type": "fact",
         "id": "1111",
-        "title": "my card"
+        "preferredPhrase": "my card"
       }]
     })
     


### PR DESCRIPTION
When a board has more than 50 cards our API returns all of the objects but the first 50 have complete data (card title, content, etc.) and the rest just have an ID. This change checks for that scenario and loads the cards 50 at a time. That way you can do something like this:

```
board = g.get_board("huge board")
print(board.cards[100].title)
```

Sometimes our API returns 'lite' board objects, like when we're searching for a board by title. These board objects don't have any items at all (the list is either empty or not included in the response at all). That's ok because in that scenario we don't bulk load any card data because:

1. We don't have the IDs so we couldn't load them if we wanted to.
2. We're not using these as full board objects. Once we find a board with the matching title we make the get call with its ID to load the full board.

I also noticed some board tests had `"title"` as a property in the JSON for cards when it should've been `"preferredPhrase"`.