### PR TITLE
misc updates

### DIFF
--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -676,6 +676,9 @@ class BundleNode:
     # we go backwards so the parts end up in the correct order.
     for index in range(len(parts) - 1, 0, -1):
       new_content = parts[index]
+      if not new_content.strip():
+        continue
+
       new_doc = BeautifulSoup(new_content, "html.parser")
       new_title = self.title
 
@@ -684,6 +687,10 @@ class BundleNode:
         new_title = element.text.strip()
         element.decompose()
         break
+
+      # if this split would end up having no content, skip it.
+      if not str(new_doc):
+        continue
 
       new_node = self.bundle.node(
         id="%s_part%s" % (self.id, index),

--- a/guru/core.py
+++ b/guru/core.py
@@ -479,7 +479,12 @@ class Guru:
     
     url = "%s/collections/%s" % (self.base_url, collection_obj.id)
     response = self.__delete(url)
-    return status_to_bool(response.status_code)
+    result = status_to_bool(response.status_code)
+
+    if result:
+      self.__clear_cache("%s/collections" % self.base_url)
+    
+    return result
 
   def upload_content(self, collection, filename, zip_path, is_sync=False):
     """internal: used by the bundle object"""
@@ -607,7 +612,12 @@ class Guru:
     
     url = "%s/groups/%s" % (self.base_url, group_obj.id)
     response = self.__delete(url)
-    return status_to_bool(response.status_code)
+    result = status_to_bool(response.status_code)
+
+    if result:
+      self.__clear_cache("%s/groups" % self.base_url)
+    
+    return result
 
   def get_group_members(self, group):
     """

--- a/tests/test_core_boards.py
+++ b/tests/test_core_boards.py
@@ -508,9 +508,6 @@ class TestCore(unittest.TestCase):
       }
     }, {
       "method": "GET",
-      "url": "https://api.getguru.com/api/v1/collections"
-    }, {
-      "method": "GET",
       "url": "https://api.getguru.com/api/v1/boards/home?collection=1234"
     }])
   
@@ -1167,7 +1164,7 @@ class TestCore(unittest.TestCase):
             "entryType": "board"
           }
         ],
-        "prevSiblingItem": "bg1"
+        "prevSiblingItem": "i2"
       }
     }
   ])


### PR DESCRIPTION
I had a few changes locally that came up from a couple of different things:

1. Handling pages that'd be empty when you split a bundle node.
2. Increasing the use of caching the `/collections` API call -- when you run a script that does a lot of operations with parameters like `collection="General"` we look up the collection each time.
3. Add a parameter so when you add a board to a board group it can be added as the first item or last item. Previously it'd be added at the top, so if you added boards 1, 2, and 3 they'd end up in the order: 3, 2, 1. The default is to add the board last which is different than the old behavior but probably makes more sense.
4. Clear cached calls when you make a new board or collection.