### PR TITLE
expand publishing metadata

### DIFF
--- a/examples/readme_publish.py
+++ b/examples/readme_publish.py
@@ -98,7 +98,7 @@ class ReadmePublisher(guru.Publisher):
         if doc.get("title") == card.title:
           return doc.get("slug")
 
-  def create_external_card(self, card, section, board, board_group, collection):
+  def create_external_card(self, card, changes, section, board, board_group, collection):
     """
     This method is called automatically when the SDK sees a card
     that it knows hasn't been published before. This means we need
@@ -121,7 +121,7 @@ class ReadmePublisher(guru.Publisher):
     # call to Readme to update this particular doc.
     return requests.post(url, json=data, auth=(README_API_TOKEN, "")).json().get("_id")
   
-  def update_external_card(self, external_id, card, section, board, board_group, collection):
+  def update_external_card(self, external_id, card, changes, section, board, board_group, collection):
     """
     This script stores metadata so it knows which cards have been
     published before. If a card has already been published to

--- a/examples/salesforce_publish.py
+++ b/examples/salesforce_publish.py
@@ -452,8 +452,8 @@ class SalesforcePublisher(guru.Publisher):
 
 if __name__ == "__main__":
   guru_user = os.environ.get("GURU_USER")
-  guru_api_token = os.environ.get("GURU_API_TOKEN")
-  g = guru.Guru(guru_user, guru_api_token)
+  guru_token = os.environ.get("GURU_TOKEN")
+  g = guru.Guru(guru_user, guru_token)
 
   publisher = SalesforcePublisher(g, dry_run=False)
   publisher.publish_collection(INTERNAL_COLLECTION)

--- a/guru/__init__.py
+++ b/guru/__init__.py
@@ -17,6 +17,10 @@ from guru.core import (
   READ_ONLY,
   AUTHOR,
   COLLECTION_OWNER,
+
+  # verification states:
+  VERIFIED,
+  UNVERIFIED,
 )
 
 from guru.publish import (

--- a/guru/core.py
+++ b/guru/core.py
@@ -37,6 +37,12 @@ READ_ONLY = "MEMBER"
 AUTHOR = "AUTHOR"
 COLLECTION_OWNER = "COLL_ADMIN"
 
+TRUSTED = "TRUSTED"
+VERIFIED = TRUSTED
+NEEDS_VERIFICATION = "NEEDS_VERIFICATION"
+UNVERIFIED = NEEDS_VERIFICATION
+
+
 def make_blue(*args):
   return " ".join(["\033[94m%s\033[0m" % text for text in args])
 
@@ -1293,13 +1299,13 @@ class Guru:
     elif verified == True or unverified == False:
       nested_expressions.append({
         "type": "trust-state",
-        "verificationState": "TRUSTED",
+        "verificationState": TRUSTED,
         "op": "EQ"
       })
     elif verified == False or unverified == True:
       nested_expressions.append({
         "type": "trust-state",
-        "verificationState": "NEEDS_VERIFICATION",
+        "verificationState": NEEDS_VERIFICATION,
         "op": "EQ"
       })
 

--- a/guru/publish.py
+++ b/guru/publish.py
@@ -410,8 +410,6 @@ class Publisher:
       self.__log("skip card", card.title)
       return
 
-    print(card.title, "added", changes.boards_added, "removed", changes.boards_removed)
-
     # scan the guru card for card to card links.
     # these should become links between external articles.
     # look for the 'data-ghq-guru-card-id' attribute and

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
 one)
-  coverage run -m unittest tests.$2
+  PUB=true E2E=true coverage run -m unittest tests.$2
   ;;
 test)
   coverage run -m unittest && coverage report && coverage html

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -200,7 +200,8 @@ class TestPublish(unittest.TestCase):
       "68fafb96-0446-46f4-b9e9-f778fdd85eb1": {
         "type": "card",
         "external_id": "1234",
-        "last_updated": "2030-01-01T00:00:00.000+0000"
+        "last_updated": "2030-01-01T00:00:00.000+0000",
+        "boards": ["SDK"]
       }
     }
     
@@ -348,9 +349,9 @@ class TestPublish(unittest.TestCase):
     with self.assertRaises(NotImplementedError):
       publisher.get_external_url(None, None)
     with self.assertRaises(NotImplementedError):
-      publisher.create_external_card(None, None, None, None, None)
+      publisher.create_external_card(None, None, None, None, None, None)
     with self.assertRaises(NotImplementedError):
-      publisher.update_external_card(None, None, None, None, None, None)
+      publisher.update_external_card(None, None, None, None, None, None, None)
     with self.assertRaises(NotImplementedError):
       publisher.delete_external_card(None)
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -47,11 +47,11 @@ class PublisherTest(guru.Publisher):
     return card.id[0:4] if card.title in self.external_data else ""
 
   # crud operations for cards
-  def create_external_card(self, card, section, board, board_group, collection):
+  def create_external_card(self, card, changes, section, board, board_group, collection):
     self.calls.append("create card %s" % card.title)
     return card.id[0:4]
   
-  def update_external_card(self, external_id, card, section, board, board_group, collection):
+  def update_external_card(self, external_id, card, changes, section, board, board_group, collection):
     self.calls.append("update card %s" % card.title)
   
   def delete_external_card(self, external_id):


### PR DESCRIPTION
This adds a few things to our Publisher class:

1. Tracking boards and tags in the publishing metadata. Changing a card's tags or boards doesn't count as a card update so its last_modified date wouldn't change, but we may still want to publish the card if it's tags or boards changed.
2. The option to skip unverified cards when publishing.
3. Record messages (using `log()` and `log_error()`) while a publisher is running so you can use these messages at the end to generate and send a report.

It also expands the Salesforce publishing example a bit.