### PR TITLE
Add delete knowledge trigger to SDK

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -2810,11 +2810,7 @@ class Guru:
     Returns:
         bool: success status of call, true if successful, false if not
     """
-
-    # if isinstance(question, Question):
-    #   url = "%s/tasks/questions/%s" % (self.base_url, question.id)
-    # else:
-    #   url = "%s/tasks/questions/%s" % (self.base_url, question)
+    
     url = "%s/newcontexts/%s" % (self.base_url, trigger_id)
     response = self.__delete(url)
     return status_to_bool(response.status_code)

--- a/guru/core.py
+++ b/guru/core.py
@@ -2793,3 +2793,28 @@ class Guru:
 
     status, file_size = download_file(url, filename, headers=headers)
     return status_to_bool(status)
+
+  def delete_knowledge_trigger(self, trigger_id):
+    """
+    Deletes knowledge trigger, by trigger ID (context ID)
+
+    ```
+    ex:
+      g.delete_knowledge_trigger("aaaaaaaa-bbbb-cccc-1111-1234abcd4321")
+
+    ```
+    
+    Args:
+        trigger_id (str): ID of knowledge trigger
+
+    Returns:
+        bool: success status of call, true if successful, false if not
+    """
+
+    # if isinstance(question, Question):
+    #   url = "%s/tasks/questions/%s" % (self.base_url, question.id)
+    # else:
+    #   url = "%s/tasks/questions/%s" % (self.base_url, question)
+    url = "%s/newcontexts/%s" % (self.base_url, trigger_id)
+    response = self.__delete(url)
+    return status_to_bool(response.status_code)

--- a/tests/test_core_knowledge_triggers.py
+++ b/tests/test_core_knowledge_triggers.py
@@ -1,0 +1,26 @@
+
+import json
+import yaml
+import unittest
+import responses
+
+from tests.util import use_guru, get_calls
+
+import guru
+
+
+class TestCore(unittest.TestCase):
+  @use_guru()
+  @responses.activate
+  def test_delete_knowledge_trigger(self, g):
+    # register the response for the API call we'll make.
+    responses.add(responses.DELETE, "https://api.getguru.com/api/v1/newcontexts/1111", status=204)
+
+    result = g.delete_knowledge_trigger("1111")
+    
+    self.assertEqual(get_calls(), [{
+      "method": "DELETE",
+      "url": "https://api.getguru.com/api/v1/newcontexts/1111"
+    }])
+
+  


### PR DESCRIPTION
Story details: https://app.shortcut.com/guru/story/67351

## Overview

In order to fulfill [this story](https://app.shortcut.com/guru/story/67351/delete-and-re-do-knowledge-triggers-for-square-compliance), I added `delete_knowledge_trigger()` to the SDK. This is called with trigger's UUID string (i.e. 11111111-aaaa-bbbb-cccc-abcd1234dcba ) as a parameter, which the `/newcontexts/{triggerId}` DELETE call will use to delete that specific knowledge trigger. 

Its intended use is to be called iteratively, against a list of trigger IDs. In the future, we may add a `Trigger` object, if we were to add the functionality to get all triggers, update triggers, create triggers, etc...