### PR TITLE
check for pagination when loading group members

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -60,7 +60,7 @@ def make_bold(*args):
 
 def get_link_header(response):
   link_header = response.headers.get("Link", "")
-  return link_header[1:link_header.find(">")]
+  return link_header[1:link_header.find(">")].strip()
 
 def status_to_bool(status_code):
   band = int(status_code / 100)
@@ -719,10 +719,8 @@ class Guru:
       return False
 
     url = "%s/groups/%s/members" % (self.base_url, group_obj.id)
-    response = self.__get(url)
-    if response.status_code == 204:
-      return []
-    return [User(u) for u in response.json() or []]
+    users = self.__get_and_get_all(url)
+    return [User(u) for u in users]
 
   def get_members(self, search="", cache=False):
     """

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1689,8 +1689,8 @@ it's multiple lines
     bundle.zip()
 
     self.assertEqual(read_html("/tmp/test_guru_markdown_blocks/cards/1.html"), """<div class="ghq-card-content__markdown" data-ghq-card-content-markdown-content="%3Cdiv%20style%3D%22background-color%3A%23F89E91%3Bcolor%3A%234A1717%3Bpadding%3A1px%3Btext-align%3Aleft%3Bfont-size%3A16px%3Bmargin-bottom%3A16px%22%3E%0A%3Cp%20style%3D%22margin%3A%2016px%22%3Etest%20content%20%3Cstrong%3Eabcd%201234.%3C%2Fstrong%3E%3C%2Fp%3E%0A%3C%2Fdiv%3E" data-ghq-card-content-type="MARKDOWN">
-<div class="" style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px">
-<p class="" style="margin: 16px">
+<div style="background-color:#F89E91;color:#4A1717;padding:1px;text-align:left;font-size:16px;margin-bottom:16px">
+<p style="margin: 16px">
 			test content
 			<strong>
 				abcd 1234.

--- a/tests/test_core_groups_and_collections.py
+++ b/tests/test_core_groups_and_collections.py
@@ -489,6 +489,44 @@ class TestCore(unittest.TestCase):
 
   @use_guru()
   @responses.activate
+  def test_get_group_members_with_pagination(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
+      "name": "Experts",
+      "id": "2222"
+    }])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/groups/2222/members", match_querystring=True, json=[
+      {}, {}, {}, {}, {}
+    ], headers={
+      "Link": "< https://api.getguru.com/api/v1/groups/2222/members?token=1>"
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/groups/2222/members?token=1", json=[
+      {}, {}, {}, {}
+    ], headers={
+      "Link": "< https://api.getguru.com/api/v1/groups/2222/members?token=2>"
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/groups/2222/members?token=2", json=[
+      {}, {}
+    ])
+
+    users = g.get_group("Experts").get_members()
+
+    self.assertEqual(len(users), 11)
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/groups"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/groups/2222/members"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/groups/2222/members?token=1"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/groups/2222/members?token=2"
+    }])
+
+  @use_guru()
+  @responses.activate
   def test_get_group_members_edge_cases(self, g):
     responses.add(responses.GET, "https://api.getguru.com/api/v1/groups", json=[{
       "name": "Experts",


### PR DESCRIPTION
We need to call `__get_and_get_all` instead of just `__get` to load group members. `__get_and_get_all` returns the JSON response as a list, rather than returning a Response object.

I also noticed when we read the `Link` response header, our tests give it a leading space (I assume I modeled it after our actual API responses) but we can strip out this whitespace.

There was also a failing bundle test since the empty class attributes get removed now.