### PR TITLE
salesforce publishing improvements

### DIFF
--- a/examples/salesforce_publish.py
+++ b/examples/salesforce_publish.py
@@ -95,7 +95,7 @@ def convert_card_to_article(card):
     # the UrlName is like the title but meant to be displayed in a URL, in Guru
     # we have the card's slug which serves the same purpose. the slug has two
     # parts, an ID and title, so we just need the second part here.
-    "UrlName": card.slug.split("/")[1],
+    "UrlName": card.slug.split("/")[1].strip("-"),
   }
 
   # we set some properties differently whether it's an internal or external article.
@@ -357,7 +357,7 @@ class SalesforcePublisher(guru.Publisher):
     # find the data category group name.
     data_category_group_name = ""
     for category in self.data_categories:
-      if category.get("label") == data_category_name:
+      if category.get("label").strip().lower() == data_category_name.strip().lower():
         data_category_name = category.get("name")
         data_category_group_name = category.get("group_name")
         break


### PR DESCRIPTION
Two fixes:

1. UrlName values can't start or end with a hyphen. We use the slug for this but if a card's title has a leading or trailing space, the slug will have a leading/trailing hyphen.
2. Data Category lookups are now done case insensitively because the SDK treats tags like that -- if you say `card.add_tag("API")` and the tag `api` exists, it'll use that tag. But if the data category in Salesforce is called "API" we still want to match that.