### PR TITLE
add remove_tag_from_card

### DIFF
--- a/guru/bundle.py
+++ b/guru/bundle.py
@@ -108,7 +108,7 @@ def clean_up_html(html):
 
     if new_class_list:
       el.attrs["class"] = new_class_list
-    elif old_class_list:
+    elif el.has_attr("class"):
       # we only remove the 'class' attribute if it was there in the first place.
       del el.attrs["class"]
 

--- a/guru/core.py
+++ b/guru/core.py
@@ -2100,6 +2100,43 @@ class Guru:
     if status_to_bool(response.status_code):
       return tag_object
 
+  def remove_tag_from_card(self, tag, card):
+    """
+    Remove a tag from a card using the DELETE call to do jut this, rather
+    than using the PUT call to update an entire card.
+
+    Args:
+      tag (str or Tag): A Tag's value, ID, or the Tag object.
+      card (str or Card): A card's slug, ID, or the Card object.
+
+    Returns:
+      bool: True if it was successful and False otherwise.
+    """
+    # look up the card object.
+    card_object = self.get_card(card)
+    if not card_object:
+      self.__log(make_red("could not find card:", card))
+      return
+
+    # if you passed in a Tag object, we use that.
+    # if not, we try to find the tag in the card's list of tags.
+    if isinstance(tag, Tag):
+      tag_object = tag
+    else:
+      tag_object = find_by_name_or_id(card_object.tags, tag)
+      # if that doesn't work, look up the tag.
+      if not tag_object:
+        tag_object = self.get_tag(tag)
+
+    if not tag_object:
+      self.__log(make_red("could not find tag:", tag))
+      return
+
+    # make the DELETE call to remove the tag.
+    url = "%s/cards/%s/tags/%s" % (self.base_url, card_object.id, tag_object.id)
+    response = self.__delete(url)
+    return status_to_bool(response.status_code)
+
   def get_board(self, board, collection=None, cache=True):
     """
     Loads a board.

--- a/guru/util.py
+++ b/guru/util.py
@@ -189,9 +189,14 @@ def find_by_name_or_id(lst, name_or_id):
   # it says "name or id" but we really need to check the 'title' and 'slug' properties too.
   name_or_id = (name_or_id or "").strip()
   for obj in lst:
+    # some objects call it 'name', some call it 'title'.
+    # for cards it's preferredPhrase but we also give them a title property.
+    # for tags it's called 'value'.
     if hasattr(obj, "name") and obj.name.strip().lower() == name_or_id.lower():
       return obj
     if hasattr(obj, "title") and obj.title.strip().lower() == name_or_id.lower():
+      return obj
+    if hasattr(obj, "value") and obj.value.strip().lower() == name_or_id.lower():
       return obj
     if obj.id.lower() == name_or_id.lower():
       return obj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4>=4.6.0
+beautifulsoup4>=4.9.0
 PyYAML>=5.3.1
 requests>=2.24.0
 python-dateutil==2.8.1

--- a/tests/test_core_tags.py
+++ b/tests/test_core_tags.py
@@ -378,3 +378,124 @@ class TestCore(unittest.TestCase):
         "suppressVerification": True
       }
     }])
+
+  @use_guru()
+  @responses.activate
+  def test_remove_tag_from_card(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1234/extended", json={
+      "id": "1234",
+      "tags": [{
+        "id": "1111",
+        "value": "api docs"
+      }]
+    })
+    responses.add(responses.DELETE, "https://api.getguru.com/api/v1/cards/1234/tags/1111", status=204)
+
+    card = g.get_card("1234")
+    card.remove_tag("api docs")
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/cards/1234/extended"
+    }, {
+      "method": "DELETE",
+      "url": "https://api.getguru.com/api/v1/cards/1234/tags/1111"
+    }])
+
+  @use_guru()
+  @responses.activate
+  def test_remove_tag_from_card2(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1234/extended", json={
+      "id": "1234",
+      "tags": [{
+        "id": "1111",
+        "value": "api docs"
+      }]
+    })
+    responses.add(responses.DELETE, "https://api.getguru.com/api/v1/cards/1234/tags/1111", status=204)
+
+    card = g.get_card("1234")
+
+    # we pass a string in here so it looks up the tag from the card's list of tags.
+    g.remove_tag_from_card("api docs", card)
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/cards/1234/extended"
+    }, {
+      "method": "DELETE",
+      "url": "https://api.getguru.com/api/v1/cards/1234/tags/1111"
+    }])
+
+  @use_guru()
+  @responses.activate
+  def test_remove_tag_from_card_where_we_look_up_the_tag(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1234/extended", json={
+      "id": "1234",
+      "tags": [] # having no tags here means we'll have to look up the tag.
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/whoami", json={
+      "team": {
+        "id": "abcd"
+      }
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/teams/abcd/tagcategories", json=[{
+      "tags": [{
+        "id": "1111",
+        "value": "api docs"
+      }],
+      "id": "2222",
+      "name": "category"
+    }])
+    responses.add(responses.DELETE, "https://api.getguru.com/api/v1/cards/1234/tags/1111", status=204)
+
+    card = g.get_card("1234")
+    card.remove_tag("api docs")
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/cards/1234/extended"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/whoami"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/teams/abcd/tagcategories"
+    }, {
+      "method": "DELETE",
+      "url": "https://api.getguru.com/api/v1/cards/1234/tags/1111"
+    }])
+
+  @use_guru()
+  @responses.activate
+  def test_remove_tag_from_card_with_invalid_tag(self, g):
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/cards/1234/extended", json={
+      "id": "1234",
+      "tags": []
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/whoami", json={
+      "team": {
+        "id": "abcd"
+      }
+    })
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/teams/abcd/tagcategories", json=[{
+      "tags": [],
+      "id": "2222",
+      "name": "category"
+    }])
+
+    card = g.get_card("1234")
+
+    # we pass a string in here so it looks up the tag from the card's list of tags.
+    g.remove_tag_from_card("api docs", card)
+
+    self.assertEqual(get_calls(), [{
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/cards/1234/extended"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/whoami"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/teams/abcd/tagcategories"
+    }])


### PR DESCRIPTION
This is a little more complicated than I originally expected because we can usually look up the tag's ID using the card's list of tags, but we don't want to rely only on that. If data is out of sync or if the card was loaded in a way that it doesn't have tag data, the card could still have a tag. As a fallback we can check the team's full list of tags to find the tag's ID.