### PR TITLE
add intercom publishing script

### DIFF
--- a/examples/intercom_publish.py
+++ b/examples/intercom_publish.py
@@ -1,0 +1,231 @@
+"""
+This script shows how to use Guru's SDK to publish cards,
+boards, or entire collections to an external site, like a
+third-party help site.
+
+This script takes the contents of a board in Guru and makes
+API calls to Intercom (https://www.intercom.com/) to create
+or update articles in Intercom based on the changes seen in
+Guru. There are a few parts to this:
+
+1. Behind the scenes, the SDK enumerates all the sections
+   and cards on the board we specify.
+2. The SDK also writes a metadata .json file to keep track
+   of which cards have been published before.
+3. Using the metadata, the SDK knows whether a card has been
+   published before and needs to be updated in Intercom or is
+   a brand new card and we need to create an article in Intercom.
+
+The SDK orchestrates everything on the Guru side. This script
+just implements the calls to Intercom's API to create and update
+each type of object. When the Guru SDK sees a card that's never
+been published before, it'll call create_external_card and we
+need to implement the Intercom API call to create the article.
+"""
+
+import os
+import guru
+import requests
+
+from urllib.parse import unquote
+
+GURU_USER = os.environ.get("GURU_USER")
+GURU_API_TOKEN = os.environ.get("GURU_API_TOKEN")
+INTERCOM_API_TOKEN = os.environ.get("INTERCOM_API_TOKEN")
+
+
+class IntercomPublisher(guru.Publisher):
+  def __init__(self, g):
+    super().__init__(g)
+
+    # we use this to cache the responses to the API calls
+    # for looking up articles, sections, or collections.
+    self.cache = {}
+
+  def get_headers(self):
+    return {
+      "Authorization": "Bearer %s" % INTERCOM_API_TOKEN
+    }
+
+  def get_all(self, url):
+    """
+    Make a GET call to Intercom's API and use its pagination
+    to load all pages of results.
+    """
+    if self.cache.get(url):
+      return self.cache.get(url)
+    
+    results = []
+    original_url = url
+
+    while url:
+      response = requests.get(url, headers=self.get_headers())
+      results += response.json().get("data")
+      url = response.json().get("pages", {}).get("next")
+
+    self.cache[original_url] = results
+    return results
+
+  def get_external_url(self, external_id, card):
+    """
+    This builds the public-facing URL for an Intercom article. We use this
+    to convert links between Guru Cards to be links between Intercom articles.
+    """
+    return "https://intercom.help/publishing-test-dev/en/articles/%s" % external_id
+
+  def find_external_board(self, guru_board):
+    """
+    This checks if a board already exists in Intercom by checking for one
+    with the same name. Boards in Guru become 'Collections' in Intercom.
+    """
+    intercom_collections = self.get_all("https://api.intercom.io/help_center/collections")
+
+    for intercom_collection in intercom_collections:
+      if intercom_collection["name"].lower() == guru_board.title.lower():
+        return intercom_collection["id"]
+
+  def create_external_board(self, board, board_group, collection):
+    """
+    If a card is in a board and we can't find a 'collection' with the
+    same name in Intercom, we'll call this function to create the
+    collection in Intercom. It'd use this API call:
+
+    https://developers.intercom.com/intercom-api-reference/reference#create-a-collection
+
+    We don't have to implement this. If we don't, then we're simply
+    requiring that new collections be created manually in Intercom.
+    This might be fine, depending on how often you plan to make
+    new collections.
+    """
+    pass
+
+  def update_external_board(self, external_id, board, board_group, collection):
+    """
+    This is similar to create_external_board except it's called when
+    a Guru Board is updated (e.g. you changed it's name) and this would
+    make the Intercom API call to update a collection:
+
+    https://developers.intercom.com/intercom-api-reference/reference#update-a-collection
+    """
+    pass
+
+  def find_external_section(self, guru_section):
+    """
+    This checks if a section already exists in Intercom by checking for one with
+    the same name. This is a little confusing because both Guru and Intercom call
+    them "sections".
+    """
+    intercom_sections = self.get_all("https://api.intercom.io/help_center/sections")
+
+    for intercom_section in intercom_sections:
+      if intercom_section["name"].lower() == guru_section.title.lower():
+        return intercom_section["id"]
+
+  def create_external_section(self, section, board, board_group, collection):
+    """
+    If a card is in a section and we can't find a section with the
+    same name in Intercom, we'll call this function to create the
+    section in Intercom. It'd use this API call:
+
+    https://developers.intercom.com/intercom-api-reference/reference#create-a-section
+
+    We don't have to implement this. If we don't, then we're simply
+    requiring that new sections be created manually in Intercom.
+    This might be fine, depending on how often you plan to make
+    new sections.
+    """
+    pass
+
+  def update_external_section(self, external_id, section, board, board_group, collection):
+    """
+    This is similar to create_external_section except it's called when
+    a Guru Section is updated (e.g. you changed it's name) and this would
+    make the Intercom API call to update a section:
+
+    https://developers.intercom.com/intercom-api-reference/reference#update-a-section
+    """
+    pass
+
+  def find_external_card(self, card):
+    """
+    This checks if a card already exists externally by looking for an Intercom
+    article with the same title.
+    """
+    articles = self.get_all("https://api.intercom.io/articles")
+
+    for article in articles:
+      if article.get("title").lower() == card.title.lower():
+        return article.get("id")
+
+  def convert_card_to_article(self, card, section, board):
+    """
+    This builds the JSON payload for creating or updating an
+    Intercom article from the given Guru Card.
+    """
+    data = {
+      "title": card.title,
+      "author_id": 5056532,
+      "body": card.content,
+      "state": "published",
+    }
+
+    # if the card is on a section, that's its parent in Intercom.
+    # if it's on a board, then that's its parent in Intercom.
+    if section:
+      data["parent_id"] = self.get_external_id(section.id)
+      data["parent_type"] = "section"
+    elif board:
+      data["parent_id"] = self.get_external_id(board.id)
+      data["parent_type"] = "collection"
+    
+    return data
+
+  def create_external_card(self, card, changes, section, board, board_group, collection):
+    """
+    This method is called automatically when the SDK sees a card
+    that it knows hasn't been published before. This means we need
+    to use Intercom's POST endpoint to create a new article.
+    """
+    data = self.convert_card_to_article(card, section, board)
+    url = "https://api.intercom.io/articles"
+
+    # This method has to return the Intercom ID of the new article. We need
+    # to remember the Intercom ID that's associated with each Guru card so
+    # the next time we publish this card we can make the 'update' call to
+    # Intercom to update this particular article.
+    return requests.post(url, json=data, headers=self.get_headers()).json().get("id")
+
+  def update_external_card(self, external_id, card, changes, section, board, board_group, collection):
+    """
+    This script stores metadata so it knows which cards have been
+    published before. If a card has already been published to
+    Intercom, it'll call this method so we can make the PUT call
+    to update the article in Intercom.
+    """
+    data = self.convert_card_to_article(card, section, board)
+    url = "https://api.intercom.io/articles/%s" % external_id
+
+    # this method returns the response object so the SDK will know
+    # if the API call to update the article was successful.
+    return requests.put(url, json=data, headers=self.get_headers())
+  
+  def delete_external_card(self, external_id):
+    # if we want to automatically delete Intercom articles when the Guru
+    # cards are archived, we could implement that here.
+    pass
+
+
+if __name__ == "__main__":
+  g = guru.Guru(GURU_USER, GURU_API_TOKEN)
+  publisher = IntercomPublisher(g)
+
+  # 'Gi6dzBxi' is the slug that identifies the board we publish to Intercom.
+  # you can find this ID in the board's URL, like:
+  # https://app.getguru.com/boards/Gi6dzBxi/Intercom-Articles
+  publisher.publish_board("Gi6dzBxi")
+
+  # for now, we haven't implemented any of the 'delete' methods. if we do want to
+  # be able to delete Intercom articles when the guru cards are archived (or when
+  # they're removed from our 'intercom' board), we'll need to implement the delete
+  # method and also call process_deletions().
+  # publisher.process_deletions()

--- a/guru/core.py
+++ b/guru/core.py
@@ -227,6 +227,7 @@ class Guru:
       self.__log(make_gray("  using cached get call:", url))
       return self.__cache[url]
     
+    original_url = url
     results = []
     auth = self.__get_auth()
     page = 0
@@ -245,7 +246,7 @@ class Guru:
       if page >= max_pages:
         break
     
-    self.__cache[url] = results
+    self.__cache[original_url] = results
     return results
 
   def __post_and_get_all(self, url, data):
@@ -2499,6 +2500,9 @@ class Guru:
       board_obj.items.append(card_obj)
     
     self.save_board(board_obj)
+
+    # clear the cache entry for this board.
+    self.__clear_cache("%s/boards/%s" % (self.base_url, board_obj.id))
 
   def add_section_to_board(self, board, section, collection=None):
     """

--- a/guru/publish.py
+++ b/guru/publish.py
@@ -263,7 +263,7 @@ class Publisher:
         if external_id:
           successful = True
     
-    if successful:
+    if successful or external_id:
       self.__update_metadata(collection.id, external_id, type="collection")
     
     for item in home_board.items:
@@ -304,7 +304,7 @@ class Publisher:
         if external_id:
           successful = True
     
-    if successful:
+    if successful or external_id:
       self.__update_metadata(board_group.id, external_id, type="board_group")
 
     for item in board_group.items:
@@ -344,7 +344,7 @@ class Publisher:
         if external_id:
           successful = True
     
-    if successful:
+    if successful or external_id:
       self.__update_metadata(board.id, external_id, type="board")
     
     for item in board.items:
@@ -383,7 +383,7 @@ class Publisher:
         if external_id:
           successful = True
     
-    if successful:
+    if successful or external_id:
       self.__update_metadata(section.id, external_id, type="section")
 
     for item in section.items:
@@ -456,5 +456,11 @@ class Publisher:
         last_modified_date=card.last_modified_date,
         boards=[b.title for b in card.boards],
         tags=[t.value for t in card.tags],
+        type="card"
+      )
+    elif external_id:
+      self.__update_metadata(
+        card.id,
+        external_id,
         type="card"
       )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,4 +1,5 @@
 
+
 import unittest
 import requests
 import mimetypes
@@ -6,6 +7,7 @@ import mimetypes
 from tests.util import use_guru
 
 import os
+import time
 import guru
 
 # these are valid credentials so these tests will hit our live API.
@@ -185,7 +187,7 @@ class TestEndToEnd(unittest.TestCase):
     # number of items changed as expected.
     board_before = g.get_board("Bored Board", collection="Sandbox")
     card.add_to_board("Bored Board")
-    board_after = g.get_board("Bored Board", collection="Sandbox")
+    board_after = g.get_board("Bored Board", collection="Sandbox", cache=False)
     card = g.get_card(card.id)
 
     self.assertEqual(len(board_before.items) + 1, len(board_after.items))
@@ -226,7 +228,8 @@ class TestEndToEnd(unittest.TestCase):
     #   "archived": True
     # })
 
-    board_after_archive = g.get_board("Bored Board", collection="Sandbox")
+    time.sleep(1)
+    board_after_archive = g.get_board("Bored Board", collection="Sandbox", cache=False)
     self.assertEqual(len(board_before.items), len(board_after_archive.items))
 
   @use_guru(SDK_E2E_USER, SDK_E2E_TOKEN)


### PR DESCRIPTION
This adds a script that publishes to Intercom. It implements the calls to:

 - Create and update Intercom articles.
 - Find Intercom collections and sections (board become Intercom Collections, Guru sections become Intercom sections)

It does not implement the calls to:

 - Create or update Intercom sections.
 - Create or update Intercom collections.

This also fixes a couple of other issues I noticed:

1. Caching wasn't working because we need to store the original request URL and associate the response data with that.
2. An end to end test was failing -- we load a board, add a new card to it, archive the card, and then assert that the board has the same number of items before those operations as it does after. This wasn't working and I thought it might be a caching issue, but that doesn't seem to be the case. I added a small delay after archiving the card and that seems to fix it.