### PR TITLE
expand card manager api parameters

### DIFF
--- a/guru/__init__.py
+++ b/guru/__init__.py
@@ -27,6 +27,15 @@ from guru.publish import (
   Publisher
 )
 
+# you might need these to check if an item on a board is
+# an instance of Section or Card.
+from guru.data_objects import (
+  Board,
+  BoardGroup,
+  Card,
+  Section
+)
+
 from guru.util import (
   MAX_FILE_SIZE,
   load_html,

--- a/guru/core.py
+++ b/guru/core.py
@@ -85,6 +85,23 @@ def is_color(color):
 def is_email(email):
   return "@" in email and len(email) > 3
 
+def parse_expression(values, type, key):
+  expression = {
+    "type": type,
+    "op": "EQ"
+  }
+
+  # if the value is a single string we assume the operation is "EQ"
+  if isinstance(values, str):
+    expression[key] = values
+  else:
+    # otherwise we assume values is like ("EQ", "PRIVATE")
+    # todo: we could be smarter and allow both orders.
+    expression["op"] = values[0]
+    expression[key] = values[1]
+
+  return expression
+
 
 class DummyResponse:
   def __init__(self, status_code=200):
@@ -1286,7 +1303,7 @@ class Guru:
   def find_cards(
     self, title="", tag="", collection="", author="", verified=None, unverified=None,
     created_before=None, created_after=None, last_modified_before=None, last_modified_after=None,
-    last_modified_by=None, archived=False
+    last_modified_by=None, archived=False, board_count=None, share_status=None
   ):
     """
     Gets a list of cards that match the criteria defined by the parameters.
@@ -1442,6 +1459,19 @@ class Guru:
         "email": last_modified_by,
         "op": "EQ"
       })
+
+    if board_count is not None:
+      nested_expressions.append({
+        "type": "count",
+        "value": "0",
+        "op": "EQ",
+        "field": "BOARDCOUNT"
+      })
+
+    if share_status:
+      nested_expressions.append(
+        parse_expression(share_status, type="share-type", key="shareType")
+      )
 
     if nested_expressions:
       data["query"] = {

--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -146,6 +146,7 @@ class Board:
         card_lookup[id] = data[id]
 
     # now that we have the full card objects, we update the entries in all the existing lists.
+    self.__update_cards_in_list(self.items, card_lookup)
     self.__update_cards_in_list(self.__cards, card_lookup)
     self.__update_cards_in_list(self.__all_items, card_lookup)
     for section in self.__sections:


### PR DESCRIPTION
I was writing a script that'd go through all board groups, boards, sections, and cards, and I realized I'd also need a way to get the list of cards not on a board. The webapp uses the card manager API for this so I added the parameters it needs.

So far, the parameters to find_cards that'd require an operator (equals, not equals, less than, etc.) had been handled one of two ways:

1. Separate parameters like `last_modified_before` and `last_modified_after`.
2. You can only use one operator, like `author` always being `EQ`.

For share status, `EQ` might be the obvious operator but to select cards not on a board, we need to specify that it's not equal to "private". So, this uses the parameter `share_status="PRIVATE"` to mean "share status equals private" and `share_status=("NE", "PRIVATE")` means "not private cards".