### PR TITLE
misc updates

### DIFF
--- a/guru/data_objects.py
+++ b/guru/data_objects.py
@@ -188,6 +188,18 @@ class Board:
   def all_items(self):
     return tuple(self.__all_items)
 
+  def get_section(self, section):
+    """
+    Returns the Section object matching the specified section name or ID.
+
+    Args:
+      section (str): The section's name or ID.
+
+    Returns:
+      Section: the Section object or None if it wasn't found.
+    """
+    return find_by_name_or_id(self.sections, section)
+
   def has_section(self, section):
     """
     Returns True if the board contains the section and False if it doesn't.
@@ -209,7 +221,7 @@ class Board:
     Returns:
       bool: True if the board contains the section and False otherwise.
     """
-    return True if find_by_name_or_id(self.sections, section) else False
+    return True if self.get_section(section) else False
 
   def add_section(self, name):
     """
@@ -1177,7 +1189,7 @@ class Card:
   def get_resolved_card_comments(self):
     return self.guru.get_card_comments(self, status="RESOLVED")
 
-  def add_to_board(self, board, section=None):
+  def add_to_board(self, board, section=None, board_group=None):
     """
     Adds the card to a board.
 
@@ -1186,6 +1198,21 @@ class Card:
       section (str, optional): The name of the section to add this card to.
     """
     return self.guru.add_card_to_board(self, board, section, collection=self.collection)
+
+  def remove_from_board(self, board):
+    """
+    Removes the card from a board.
+
+    Args:
+      board (str or Board): The name of the board you're removing the card from, or the Board object.
+
+    Returns:
+      bool: True if it was successful and False otherwise.
+    """
+    return self.guru.remove_card_from_board(self, board, self.collection)
+
+  def move_to_collection(self, collection, timeout=0):
+    return self.guru.move_card_to_collection(self, collection, timeout=timeout)
 
   def download_as_pdf(self, filename):
     return self.guru.download_card_as_pdf(self, filename)

--- a/tests/test_core_boards.py
+++ b/tests/test_core_boards.py
@@ -124,6 +124,11 @@ class TestCore(unittest.TestCase):
       "name": "General"
     }])
     responses.add(responses.PUT, "https://api.getguru.com/api/v1/boards/home/entries?collection=1234", json=[])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards?collection=1234", json=[{
+      "id": "1111",
+      "title": "New Board"
+    }])
+    responses.add(responses.GET, "https://api.getguru.com/api/v1/boards/1111", json={})
 
     result = g.make_board("New Board", collection="General", description="test")
 
@@ -141,6 +146,12 @@ class TestCore(unittest.TestCase):
           "description": "test"
         }]
       }
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards?collection=1234"
+    }, {
+      "method": "GET",
+      "url": "https://api.getguru.com/api/v1/boards/1111"
     }])
 
   @use_guru()


### PR DESCRIPTION
1. Add `move_card_to_collection` which is very similar to `move_board_to_collection` which we already have.
2. When selecting a board like `g.get_board("Getting Started", collection="Engineering")` this adds a `board_group` parameter in case there are two boards called "Getting Started" -- as long as they're in different board groups, this will find the right one.
3. Add some convenience methods in data_objects like being able to remove a card from a board or being able to get a section within a board.

todo:
 - [ ] add tests for the new board_group parameter on the get_board call.