### PR TITLE
add save_json, load_json, and tests

### DIFF
--- a/guru/__init__.py
+++ b/guru/__init__.py
@@ -47,5 +47,7 @@ from guru.util import (
   copy_file,
   clear_dir,
   format_timestamp,
-  compare_datetime_string
+  compare_datetime_string,
+  save_json,
+  load_json
 )

--- a/guru/util.py
+++ b/guru/util.py
@@ -2,6 +2,7 @@
 import re
 import os
 import sys
+import json
 import time
 import yaml
 import shutil
@@ -265,6 +266,19 @@ def compare_datetime_string(date_to_compare, comparison, date_to_compare_against
     return date_to_compare != date_to_compare_against
   else:
     raise ValueError("Please provide a valid comparison option (lt, gt, lt_or_eq, gt_or_eq, eq, ne")
+
+def load_json(filename):
+  """returns JSON object from file."""
+  try:
+    with open(filename, "r") as file_in:
+      return json.loads(file_in.read())
+  except:
+    return {}
+
+def save_json(filename, data):
+  """writes data to a file, as JSON."""
+  with open(filename, "w") as file_out:
+    file_out.write(json.dumps(data, indent=2))
 
 
 

--- a/tests/test.json
+++ b/tests/test.json
@@ -1,0 +1,4 @@
+{
+  "test": "test",
+  "another_test": "yet another test string"
+}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 
 import json
 import yaml
+import os
 import unittest
 import responses
 
@@ -41,6 +42,22 @@ class TestUtil(unittest.TestCase):
     bundle = g.bundle("http")
     doc = bundle.load_html("./tests/test_sync_with_local_files_node1.html")
     self.assertEqual(doc.find("img").attrs["src"], "tests/test_sync_with_local_files_test.png")
+
+  @use_guru()
+  def test_load_json_with_local_file(self, g):
+    doc = guru.load_json("./tests/test.json")
+    self.assertEqual(doc["test"], "test")
+    self.assertEqual(doc["another_test"], "yet another test string")
+ 
+  @use_guru()
+  def test_save_json_to_tmp_folder(self, g):
+    data = {
+      'test': "json test"
+    }
+    guru.save_json("/tmp/test_sample.json", data)
+    self.assertTrue(os.path.isfile("/tmp/test_sample.json"))
+    doc = guru.load_json("/tmp/test_sample.json")
+    self.assertEqual(doc["test"], "json test")
 
   @use_guru()
   @responses.activate


### PR DESCRIPTION
## Overview

This PR adds utility functions for saving JSON to a local file, and loading JSON from a local file.

## Testing

Run `test_load_json_with_local_file` and `test_save_json_to_tmp_folder` in `test_util.py`