### PR TITLE
Referencing the obj, not the string variable

### DIFF
--- a/guru/core.py
+++ b/guru/core.py
@@ -2598,7 +2598,7 @@ class Guru:
       raise ValueError(f"couldn't find source folder! : {source_folder}")
 
     # find the card in the source folder...
-    source_card_obj = find_by_name_or_id(source_folder.cards, source_card_id)
+    source_card_obj = find_by_name_or_id(source_folder_obj.cards, source_card_id)
     # check if we have an object...
     if not source_card_obj:
       raise ValueError(f"couldn't find card in source_folder!: {card}")


### PR DESCRIPTION
This should be referencing the object being found in line 2596, not the string variable passed into the function since there is no context of cards for the variable. Thought I was losing my mind with the way our collection's were structured and then realized this bug after way too long of trying to reconfigure some collections.